### PR TITLE
Framework 0.9: caminho fácil e piso AAA operacional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Alan Studios Framework · 0.8
+# Alan Studios Framework · 0.9
 
 Harness thin para criar e evoluir games com IA. Compartilha conceitos, processo,
 seleção de contexto e evidência. Cada jogo continua usando sua engine, suas regras,
 seus assets e seus validadores.
+
+Fácil de começar: um pedido vira um ciclo jogável, sem nove templates vazios.
+Difícil de rebaixar: feel, áudio e receita de conteúdo fazem parte do recorte,
+não de um “polimento depois”. AAA, aqui, é o acabamento pretendido demonstrado
+numa fatia — não um motor, um orçamento nem uma nota automática.
 
 Não é um motor. Não publica sozinho. Não mede diversão.
 
@@ -19,6 +24,7 @@ No Codex ou no Claude, invoque **`$game-dev`** com o projeto e a mudança deseja
 ```
 $game-dev crie um conto jogável em Canvas a partir do acervo existente
 $game-dev desenvolva o Game Brief e o GDD desta ideia, usando MDA
+$game-dev o pulo ainda não tem peso; ajuste o feel e o áudio dessa ação
 ```
 
 A fonte é [SKILL.md](SKILL.md). Copie-a para o atalho do host
@@ -31,7 +37,13 @@ python3 scripts/game.py discover --root /caminho/do/laboratorio
 python3 scripts/game.py context /caminho/do/jogo --focus create --root /caminho/do/laboratorio
 python3 scripts/game.py scan /caminho/do/jogo --root /caminho/do/laboratorio
 python3 scripts/game.py context /caminho/do/jogo --focus architecture --stage tdd --root /caminho/do/laboratorio
+python3 scripts/game.py context /caminho/do/jogo --focus feel --root /caminho/do/laboratorio
+python3 scripts/game.py context /caminho/do/jogo --focus audio --root /caminho/do/laboratorio
 ```
+
+Focos: `create`, `mechanics`, `lifecycle`, `content`, `visual`, `audio`,
+`feel`, `network`, `architecture`. Jogo novo começa em `create`. Acabamento
+do verbo usa `feel` e `audio`. Contrato: [ambição](references/ambition.md).
 
 O contexto entrega caminhos para leitura, registros já existentes, catálogos de
 estudo (se um irmão `Games-Frameworks` existir, ou `GAMES_FRAMEWORKS_ROOT`),
@@ -99,10 +111,12 @@ python3 scripts/game.py check-plan caminho/do/trabalho.json --root /caminho/do/l
 
 Receitas: [criar](recipes/create.md), [mecânicas](recipes/mechanics.md),
 [ciclo de vida](recipes/lifecycle.md), [conteúdo](recipes/content.md),
-[visual](recipes/visual.md), [rede](recipes/network.md),
-[arquitetura](recipes/architecture.md). `--focus architecture` ou `--stage tdd`
-carrega a receita de arquitetura. A skill aplica quando a mudança afeta
-contratos ou responsabilidades; o CLI só seleciona referências.
+[visual](recipes/visual.md), [áudio](recipes/audio.md), [feel](recipes/feel.md),
+[rede](recipes/network.md), [arquitetura](recipes/architecture.md).
+`--focus architecture` ou `--stage tdd` carrega a receita de arquitetura.
+`--focus feel` e `--focus audio` carregam acabamento do verbo.
+A skill aplica quando a mudança afeta contratos ou responsabilidades; o CLI
+só seleciona referências.
 
 ## Áudio (opcional)
 
@@ -128,7 +142,7 @@ python3 scripts/game.py verify /caminho/do/jogo --output /tmp/jogo-qa-01 --root 
 ```
 
 `--command` vai por último. Não há shell implícito. Cada execução cria uma pasta
-inédita. Destino existente é recusado. Build verde não prova arte, reinício, rede
+inédita. Destino existente é recusado. Build verde não prova arte, feel, áudio, reinício, rede
 nem que o jogo é divertido. `experience_status` continua `not_assessed`.
 
 ## Três camadas
@@ -143,7 +157,8 @@ nem que o jogo é divertido. `experience_status` continua `not_assessed`.
 ## O que este repositório não é
 
 Não há engine comum, API universal de ações, avaliação automática de diversão
-ou publicação automática. Os jogos do [playground](https://games.alanicolas.com/)
+ou publicação automática. “AAA” neste texto é piso de acabamento da slice, não
+certificado de mercado. Os jogos do [playground](https://games.alanicolas.com/)
 continuam com a própria engine; este harness não reivindica tê-los produzido.
 
 Os oito frameworks externos foram estudados em recortes; seus testes não foram
@@ -158,4 +173,4 @@ Recibos brutos de execução e o acervo sonoro ficam no laboratório.
 python3 -m unittest discover -s tests -v
 ```
 
-Histórico 0.1–0.8: [adoção](adoption.md).
+Histórico 0.1–0.9: [adoção](adoption.md).

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ python3 scripts/game.py context /caminho/do/jogo --stage aaa --root /caminho/do/
 ```
 
 Sem `--output`, `template` só imprime. Com ele, cria um rascunho novo e recusa
-sobrescrita, inclusive de symlinks. Gerar `template audit` não executa auditoria.
+sobrescrita, inclusive de symlinks. Gerar `template audit` não executa auditoria. Gerar `template aaa` não
+certifica acabamento nem publisher.
 
 **REUSE → ADAPT → CREATE.** CREATE só entra com lacuna explícita.
 O [contrato JSON](assets/work.example.json) formaliza uma decisão nova;

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ seleção de contexto e evidência. Cada jogo continua usando sua engine, suas r
 seus assets e seus validadores.
 
 Fácil de começar: um pedido vira um ciclo jogável, sem nove templates vazios.
-Difícil de rebaixar: feel, áudio e receita de conteúdo fazem parte do recorte,
-não de um “polimento depois”. AAA, aqui, é o acabamento pretendido demonstrado
-numa fatia — não um motor, um orçamento nem uma nota automática.
+Difícil de rebaixar: feel, áudio, pacing e receita de conteúdo fazem parte do
+recorte, não de um “polimento depois”. “AAA” aqui é só o piso de acabamento da
+slice — não tier de publisher, orçamento nem adjetivo de trailer. O alvo
+honesto com IA é AA / Triple-I nesse piso.
 
 Não é um motor. Não publica sozinho. Não mede diversão.
 
@@ -158,7 +159,8 @@ nem que o jogo é divertido. `experience_status` continua `not_assessed`.
 
 Não há engine comum, API universal de ações, avaliação automática de diversão
 ou publicação automática. “AAA” neste texto é piso de acabamento da slice, não
-certificado de mercado. Os jogos do [playground](https://games.alanicolas.com/)
+tier de publisher nem certificado de mercado. O alvo honesto com IA é
+AA / Triple-I nesse piso. Os jogos do [playground](https://games.alanicolas.com/)
 continuam com a própria engine; este harness não reivindica tê-los produzido.
 
 Os oito frameworks externos foram estudados em recortes; seus testes não foram

--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ dependências, não esteira rígida. Um jogo pequeno pode reunir essas decisões
 um documento.
 
 Nove templates do ciclo: brief, mda, gdd, poc, prd, tdd, vertical-slice, mvp, qa.
-Três complementos: `art-bible`, `devlog`, `audit`.
+Quatro complementos: `art-bible`, `devlog`, `audit`, `aaa` (checklist de
+piso de acabamento; não certifica publisher).
 
 ```sh
 python3 scripts/game.py context /caminho/do/jogo --focus content --stage gdd --root /caminho/do/laboratorio
 python3 scripts/game.py template brief --project meu-jogo
 python3 scripts/game.py template art-bible --project meu-jogo --output /tmp/meu-jogo-art.md
+python3 scripts/game.py template aaa --project meu-jogo
+python3 scripts/game.py context /caminho/do/jogo --stage aaa --root /caminho/do/laboratorio
 ```
 
 Sem `--output`, `template` só imprime. Com ele, cria um rascunho novo e recusa

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ um documento.
 
 Nove templates do ciclo: brief, mda, gdd, poc, prd, tdd, vertical-slice, mvp, qa.
 Quatro complementos: `art-bible`, `devlog`, `audit`, `aaa` (checklist de
-piso de acabamento; não certifica publisher).
+piso). O `context` expõe `finish` (núcleo / produto / promessa / mercado).
+Slice, QA, create, feel e audio carregam a guia; `template aaa` não certifica.
 
 ```sh
 python3 scripts/game.py context /caminho/do/jogo --focus content --stage gdd --root /caminho/do/laboratorio

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,58 +5,90 @@ description: Criar, evoluir, depurar e verificar jogos com IA, partindo do acerv
 
 # Game Dev
 
-Use este processo em qualquer engine. O objetivo é uma experiência jogável com
-evidência, preservando a direção do usuário e a qualidade visual aprovada.
+Use em qualquer engine. O objetivo é uma experiência jogável no **acabamento
+pretendido**, com evidência — fácil de começar, difícil de rebaixar. AAA aqui
+é o piso do recorte (verbo, feel, áudio, mundo, receita de conteúdo), não um
+motor nem uma nota automática.
 
-1. Resolva o projeto e a tarefa. Execute `python3 scripts/game.py context
-   <projeto> --focus <foco> --root <laboratorio>` a partir deste repositório
-   (ou o caminho absoluto do script). Focos: `create`, `mechanics`, `lifecycle`,
-   `content`, `visual`, `network`, `architecture`. Leia os AGENTS aplicáveis,
-   os registros atuais, os catálogos em `studies` e somente as referências
-   indicadas. `capabilities.mentioned` aponta arquivo local; não prova pause,
-   reset, seed nem determinismo.
-   Comece por `foundation.read_first`/`records`; confira `basis`, `via` e os limites.
-   **Checagem automática:** `context` já executa `scan`. Se
-   `foundation.audit.required` for verdadeiro, avise as lacunas com `audit.notice`
-   e comece o levantamento conforme [auditoria de projeto](references/project-audit.md).
-   Não peça um segundo consentimento para documentar o mínimo; respeite restrição
-   explícita na conversa atual. Sem projeto identificável, não invente um alvo.
-   Em “continue”/“vamos avançar”, use `--event resume` e leia `continuity.sources`.
-   Fonte encontrada não é tarefa validada. Siga
-   [continuidade e retomada](references/process.md#continuidade-e-retomada).
-2. Defina sensação pretendida, verbo central, cenário, restrições e prova de
-   conclusão. Leia [processo](references/process.md) e
-   [qualidade](references/quality.md). Para criação ou pré-produção, siga
-   [o ciclo criativo](references/preproduction.md): Game Brief, MDA/GDD, PoC,
-   PRD/TDD, vertical slice, MVP e QA/playtest. Use `context <projeto> --stage
-   <etapa>` para carregar só o template pertinente; `template <etapa> --project
-   <projeto>` imprime um rascunho. Reaproveite documentos existentes; um jogo
-   pequeno pode reunir essas decisões em um documento.
-   O design system do jogo (template `art-bible`) é conteúdo mínimo; o arquivo
-   separado é opcional se outro canônico cobrir. Contrato:
-   [design system do jogo](references/game-design-system.md).
-   **Direção aprovada:** use `--event direction-approved` e sincronize a base
-   mínima no mesmo turno, mesmo com nove candidatos encontrados.
-3. **REUSE → ADAPT → CREATE.** Busque no jogo, no acervo e nas fontes
-   pertinentes. Se o laboratório tiver `shared/sfx`, use `sfx search` antes de
-   baixar som. Sem 8-bit, chiptune, jsfxr ou Kenney arcade como padrão. Leia
-   candidatos e consumidores. CREATE exige lacuna explícita. Para trabalho novo
-   sem registro, use [o contrato](assets/work.example.json); `check-plan` valida
-   a estrutura, não o mérito da escolha.
-4. Ligue intenção/GDD → requisitos/aceite → decisões técnicas → tarefas →
-   evidência. Se a mudança afetar responsabilidades, contratos, estado/tempo,
-   saves, renderização ou integrações, aplique
-   [arquitetura](recipes/architecture.md). `--focus architecture` ou `--stage tdd`
-   carrega a receita. Implemente uma fatia jogável. Não acrescente um runtime
-   comum, uma hierarquia de agentes ou IA por quadro.
-5. Verifique com os validadores existentes e com o cenário real. `verify`
-   registra comandos explícitos e logs. Build verde não comprova diversão,
-   arte, reinício, rede, direitos de assets nem aprovação humana. Capacidade
-   desconhecida permanece desconhecida até ser demonstrada.
-6. Compare antes/depois em condições equivalentes e em movimento quando houver
-   efeito visual. Corrija regressões, registre decisões e hipóteses descartadas,
-   cumpra `continuity.before_close` e `documentation.before_close`. Não promova
-   scaffold a jogo concluído. Não publique nem delegue sem autorização aplicável.
+Focos: `create`, `mechanics`, `lifecycle`, `content`, `visual`, `audio`,
+`feel`, `network`, `architecture`.
+
+## Primeira sessão (jogo novo ou recorte novo)
+
+Não gere nove templates. Não peça o usuário para conhecer o harness.
+
+1. Resolva fantasia, verbo, plataforma e a maior incerteza. Assuma o resto
+   com registro; pergunte só o que impede de jogar.
+2. Execute `python3 scripts/game.py context <projeto> --focus create
+   --root <laboratorio>` a partir deste repositório (ou o caminho absoluto
+   do script). Leia `read_next`, `foundation.read_first` e
+   [ambição](references/ambition.md). Sem projeto identificável, não invente
+   um alvo.
+3. Adapte um brief curto ou a seção equivalente no canônico existente.
+4. Construa um ciclo: perceber → decidir → agir → consequência → reinício.
+   Em seguida o feel e o áudio **desse** verbo (`--focus feel`, `--focus audio`).
+5. Compare em movimento. Diga uma próxima ação com prova. Título e cores
+   novos não demonstram experiência nova.
+
+Escala no brief: jam/conto, produto ou AAA-shaped. A escala muda quantidade
+de documentos, não o piso do verbo. Detalhe: [criar](recipes/create.md).
+
+## Jogo existente e continuidade
+
+Execute `context <projeto> --focus <foco>`. `context` já corre `scan`.
+Comece por `foundation.read_first`/`records`; confira `basis`, `via` e os
+limites. `capabilities.mentioned` aponta arquivo local; não prova pause,
+reset, seed nem determinismo.
+
+Se `foundation.audit.required` for verdadeiro, avise com `audit.notice` e
+comece o levantamento em [auditoria](references/project-audit.md). Não peça
+segundo consentimento para documentar o mínimo; restrição explícita na
+conversa atual continua valendo.
+
+Em “continue”/“vamos avançar”, use `--event resume` e leia
+`continuity.sources`. Fonte encontrada não é tarefa validada. Siga
+[continuidade](references/process.md#continuidade-e-retomada).
+
+## Direção, reuso e implementação
+
+Leia [processo](references/process.md) e [qualidade](references/quality.md).
+Pré-produção: [ciclo criativo](references/preproduction.md).
+`context --stage <etapa>` carrega o template; `template <etapa> --project
+<projeto>` imprime um rascunho. Jogo pequeno pode reunir as decisões em um
+documento. O design system (template `art-bible`) é conteúdo mínimo; arquivo
+separado é opcional se outro canônico cobrir.
+[Contrato](references/game-design-system.md).
+
+**Direção aprovada:** `--event direction-approved` e sincronize a base
+mínima no mesmo turno, mesmo com nove candidatos encontrados.
+
+**REUSE → ADAPT → CREATE.** Busque no jogo, no acervo e nas fontes
+pertinentes. Com `shared/sfx`, `sfx search` antes de baixar som. Sem 8-bit,
+chiptune, jsfxr ou Kenney arcade como padrão. CREATE exige lacuna explícita.
+Trabalho novo sem registro: [contrato](assets/work.example.json); `check-plan`
+valida a estrutura, não o mérito.
+
+Ligue intenção/GDD → requisitos/aceite → decisões técnicas → tarefas →
+evidência. Mudança em contratos, estado/tempo, saves, renderização ou
+integrações: [arquitetura](recipes/architecture.md)
+(`--focus architecture` ou `--stage tdd`). Implemente uma fatia jogável.
+Não acrescente runtime comum, hierarquia de agentes ou IA por quadro.
+
+## Verificar e encerrar
+
+Use os valores do próprio jogo e o cenário real. `verify` registra comandos
+explícitos e logs. Build verde não comprova diversão, arte, feel, áudio,
+reinício, rede, direitos nem aprovação humana. Capacidade desconhecida
+permanece desconhecida até ser demonstrada. `experience_status` continua
+`not_assessed` até haver observação em movimento.
+
+Compare antes/depois em condições equivalentes. Corrija regressões,
+registre decisões e hipóteses descartadas, cumpra `continuity.before_close`
+e `documentation.before_close`. Não promova scaffold a slice nem slice a
+jogo concluído. Não publique nem delegue sem autorização aplicável.
+
+Não chame o recorte de AAA se a slice não demonstra as barras da escala
+escolhida. [Ambição](references/ambition.md).
 
 Fontes detalhadas sob demanda: [mapa dos estudos](references/sources.md).
 Comandos, limites e adoção: [README](README.md).

--- a/SKILL.md
+++ b/SKILL.md
@@ -90,11 +90,11 @@ registre decisões e hipóteses descartadas, cumpra `continuity.before_close`
 e `documentation.before_close`. Não promova scaffold a slice nem slice a
 jogo concluído. Não publique nem delegue sem autorização aplicável.
 
-Não chame o recorte de AAA — nem de “quase AAA” — se a slice não demonstra
-as barras da escala (incluindo pacing, sincronia do impacto e repeatability).
-Checklist preenchível: `context --stage aaa` ou `template aaa`. Completar
-linhas não certifica o jogo; N/A exige motivo.
-[Ambição](references/ambition.md), [checklist](references/aaa-checklist.md).
+Não chame o recorte de AAA — nem de “quase AAA” — se o perfil em
+`finish` (núcleo; produto se a escala pedir; promessas só se o brief as
+tiver) não foi observado. Na primeira sessão **não** gere `template aaa`.
+Na slice ou em “está AAA?”, leia `finish` e [o guia](references/aaa-checklist.md);
+grave no canônico. Completar linhas não certifica. `N/A` exige motivo.
 
 Fontes detalhadas sob demanda: [mapa dos estudos](references/sources.md).
 Comandos, limites e adoção: [README](README.md).

--- a/SKILL.md
+++ b/SKILL.md
@@ -92,7 +92,9 @@ jogo concluído. Não publique nem delegue sem autorização aplicável.
 
 Não chame o recorte de AAA — nem de “quase AAA” — se a slice não demonstra
 as barras da escala (incluindo pacing, sincronia do impacto e repeatability).
-[Ambição](references/ambition.md).
+Checklist preenchível: `context --stage aaa` ou `template aaa`. Completar
+linhas não certifica o jogo; N/A exige motivo.
+[Ambição](references/ambition.md), [checklist](references/aaa-checklist.md).
 
 Fontes detalhadas sob demanda: [mapa dos estudos](references/sources.md).
 Comandos, limites e adoção: [README](README.md).

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,9 +6,10 @@ description: Criar, evoluir, depurar e verificar jogos com IA, partindo do acerv
 # Game Dev
 
 Use em qualquer engine. O objetivo é uma experiência jogável no **acabamento
-pretendido**, com evidência — fácil de começar, difícil de rebaixar. AAA aqui
-é o piso do recorte (verbo, feel, áudio, mundo, receita de conteúdo), não um
-motor nem uma nota automática.
+pretendido**, com evidência — fácil de começar, difícil de rebaixar. “AAA”
+neste framework é só o piso da slice (verbo, feel sincronizado, áudio, pacing,
+mundo, receita repetível). Não é tier de publisher, orçamento nem adjetivo
+de trailer. O alvo honesto com IA é AA / Triple-I nesse piso.
 
 Focos: `create`, `mechanics`, `lifecycle`, `content`, `visual`, `audio`,
 `feel`, `network`, `architecture`.
@@ -30,8 +31,10 @@ Não gere nove templates. Não peça o usuário para conhecer o harness.
 5. Compare em movimento. Diga uma próxima ação com prova. Título e cores
    novos não demonstram experiência nova.
 
-Escala no brief: jam/conto, produto ou AAA-shaped. A escala muda quantidade
-de documentos, não o piso do verbo. Detalhe: [criar](recipes/create.md).
+Escala no brief: jam/conto, produto ou AA / Triple-I (piso de acabamento).
+A escala muda quantidade de documentos, não o piso do verbo. Não chame o
+build de AAA. Detalhe: [criar](recipes/create.md),
+[ambição](references/ambition.md).
 
 ## Jogo existente e continuidade
 
@@ -87,8 +90,9 @@ registre decisões e hipóteses descartadas, cumpra `continuity.before_close`
 e `documentation.before_close`. Não promova scaffold a slice nem slice a
 jogo concluído. Não publique nem delegue sem autorização aplicável.
 
-Não chame o recorte de AAA se a slice não demonstra as barras da escala
-escolhida. [Ambição](references/ambition.md).
+Não chame o recorte de AAA — nem de “quase AAA” — se a slice não demonstra
+as barras da escala (incluindo pacing, sincronia do impacto e repeatability).
+[Ambição](references/ambition.md).
 
 Fontes detalhadas sob demanda: [mapa dos estudos](references/sources.md).
 Comandos, limites e adoção: [README](README.md).

--- a/adoption.md
+++ b/adoption.md
@@ -3,6 +3,14 @@
 Histórico das versões 0.1–0.9. Recibos brutos de execução e o acervo sonoro
 ficam no laboratório; aqui permanece o que a versão afirma e o que ela não afirma.
 
+## 0.9.2 — Checklist de piso de acabamento
+
+Etapa `aaa`: [guia](references/aaa-checklist.md) e
+[template](assets/templates/aaa.md). 16 grupos (CHK-0 a CHK-16), estados
+`não executado` / `observado` / `inconclusivo` / `N/A`. Completar linhas não
+certifica publisher. Tier de mercado fica na seção 16 como contexto. Jam
+pode marcar o resto `N/A` com a escala.
+
 ## 0.9.1 — Tier de mercado ≠ piso de acabamento
 
 Pesquisa de 2026-09-09 dobrada em [ambição](references/ambition.md) e

--- a/adoption.md
+++ b/adoption.md
@@ -3,6 +3,15 @@
 Histórico das versões 0.1–0.9. Recibos brutos de execução e o acervo sonoro
 ficam no laboratório; aqui permanece o que a versão afirma e o que ela não afirma.
 
+## 0.9.3 — Checklist adaptado ao harness
+
+O checklist deixa de ser só `--stage aaa`. `context` expõe `finish`
+(núcleo / produto / promessa / mercado e a ação). Slice, QA, `create`,
+`feel` e `audio` carregam a [guia](references/aaa-checklist.md); o
+template inteiro só na etapa `aaa`. Scanner trata o documento como
+candidato de QA — continua havendo nove áreas. Primeira sessão não gera
+o arquivo.
+
 ## 0.9.2 — Checklist de piso de acabamento
 
 Etapa `aaa`: [guia](references/aaa-checklist.md) e

--- a/adoption.md
+++ b/adoption.md
@@ -3,6 +3,15 @@
 Histórico das versões 0.1–0.9. Recibos brutos de execução e o acervo sonoro
 ficam no laboratório; aqui permanece o que a versão afirma e o que ela não afirma.
 
+## 0.9.1 — Tier de mercado ≠ piso de acabamento
+
+Pesquisa de 2026-09-09 dobrada em [ambição](references/ambition.md) e
+[sources](references/sources.md#aaa-tier-e-piso-09). AAA de publisher é
+rótulo financeiro (sem certificação). O harness usa “AAA” só como piso da
+slice. Escala de produto ambicioso passa a **AA / Triple-I**. Barras novas:
+sincronia no frame do impacto, pacing/latência, repeatability da slice.
+Nenhum orçamento citado vira meta.
+
 ## 0.9 — Facilidade e piso AAA operacional
 
 Caminho curto na skill e em [criar](recipes/create.md): primeira sessão chega a

--- a/adoption.md
+++ b/adoption.md
@@ -1,7 +1,16 @@
 # Adoção — Alan Studios Framework
 
-Histórico das versões 0.1–0.8. Recibos brutos de execução e o acervo sonoro
+Histórico das versões 0.1–0.9. Recibos brutos de execução e o acervo sonoro
 ficam no laboratório; aqui permanece o que a versão afirma e o que ela não afirma.
+
+## 0.9 — Facilidade e piso AAA operacional
+
+Caminho curto na skill e em [criar](recipes/create.md): primeira sessão chega a
+um ciclo jogável sem gerar nove templates. Focos [feel](recipes/feel.md) e
+[áudio](recipes/audio.md). Contrato [ambição](references/ambition.md): AAA é
+acabamento demonstrado na slice, não motor nem nota. Escala jam / produto /
+AAA-shaped muda quantidade, não o piso do verbo. O harness continua thin:
+não mede diversão, não publica, não escolhe engine.
 
 ## 0.8 — Arquitetura proporcional
 

--- a/assets/templates/aaa.md
+++ b/assets/templates/aaa.md
@@ -1,202 +1,219 @@
 # Checklist de piso de acabamento — {{PROJECT}}
 
 Projeto: {{PROJECT_PATH}}
-Status: rascunho. Preencher este arquivo **não** certifica AAA de publisher,
-não mede diversão e não autoriza publicar. “AAA” = piso da fatia observada.
+Status: rascunho. Preencher **não** certifica AAA de publisher, não mede
+diversão e não autoriza publicar. “AAA” = piso da fatia observada.
 Contrato: `framework/references/ambition.md` e
 `framework/references/aaa-checklist.md`.
 
-- Escala: [jam/conto · produto · AA / Triple-I].
-- Recorte observado: [slice / capítulo / verbo; o que está fora].
-- Promessas do recorte: [cinemática, HUD, save, rede, localização, acesso…].
-- Referência aprovada: [localizador, quem aprovou, o que não cobre].
+- Escala: [jam/conto · produto · AA / Triple-I] → perfil do `finish`.
+- Recorte: [slice / capítulo / verbo; o que está fora].
+- Promessas: [cinemática, HUD, save, rede, locale, haptic, 30/60/120…].
+- Referência aprovada: [localizador, quem, o que não cobre].
 - Observador / data / versão / dispositivo / entrada: [preencher].
-- Legenda: `não executado` · `observado` · `inconclusivo` · `N/A` (motivo).
+- Origem: ID canônico (GDD-M01, FR-001, foco feel…) ou “recorte”.
 
-Não some linhas. Screenshot isolada não fecha feel, animação, câmera, mix
-nem pacing. N/A exige motivo. Vermelho material bloqueia o adjetivo.
+Jam: só **núcleo**; resto `N/A` com a escala. Não abra este arquivo na
+primeira sessão. Produto/AA: núcleo + produto + promessas do brief, na slice.
+Mercado nunca reprova jam. Não some linhas. Still não fecha feel/mix/pacing.
 
-## 0. Contrato — CHK-0
+Legenda: `não executado` · `observado` · `inconclusivo` · `N/A` (motivo).
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-0.1 | Escala e recorte estão explícitos; o adjetivo “AAA” não foi usado sem as barras | Brief/slice; busca pelo adjetivo no recorte | não executado | |
-| CHK-0.2 | Direção aprovada tem alcance; o que ela não cobre está escrito | Art Bible / conversa; mock ≠ mecânica | não executado | |
-| CHK-0.3 | Scaffold, PoC e slice não estão confundidos | Nome do build vs. comportamento | não executado | |
-| CHK-0.4 | Itens não prometidos estão `N/A` com motivo; nada foi inventado para “completar AAA” | Rede, live ops, localização, mocap… | não executado | |
+## Núcleo — qualquer escala após um ciclo jogável
 
-## 1. Verbo e decisão — CHK-1
+### 0. Contrato — CHK-0 · núcleo
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-1.1 | Há um verbo central nomeado e jogável | GDD + uma partida curta | não executado | |
-| CHK-1.2 | A escolha muda estado, rota, recurso ou expectativa | Alternativa A vs. B no mesmo cenário | não executado | |
-| CHK-1.3 | O risco é legível **antes** da punição | Informação disponível no momento da ação | não executado | |
-| CHK-1.4 | Recusa é distinta de sucesso (estado e feedback) | Recurso insuficiente, alvo inválido, após término | não executado | |
-| CHK-1.5 | Não há opção sempre dominante no recorte, ou isso é decisão explícita | Duas alternativas sob o mesmo cenário | não executado | |
-| CHK-1.6 | Término e reinício do ciclo estão definidos e jogáveis | Vitória, derrota, saída, repeat | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-0.1 | Escala e recorte explícitos; “AAA” não usado sem as barras | Brief/slice; busca do adjetivo | brief | não executado | |
+| CHK-0.2 | Direção aprovada tem alcance; o que não cobre está escrito | Art Bible / conversa; mock ≠ mecânica | art-bible | não executado | |
+| CHK-0.3 | Scaffold, PoC e slice não estão confundidos | Nome do build vs. comportamento | slice | não executado | |
+| CHK-0.4 | Fora do perfil está `N/A` com motivo; nada inventado para “completar AAA” | Rede, live ops, locale, mocap | finish | não executado | |
 
-## 2. Primeiro minuto — CHK-2
+### 1. Verbo e decisão — CHK-1 · núcleo
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-2.1 | A primeira ação ensina o verbo sem mural que bloqueia o jogo | Cold start, instrução neutra | não executado | |
-| CHK-2.2 | Input, frame e câmera do primeiro minuto não denunciam atraso nem stutter | Observação em movimento no boot | não executado | |
-| CHK-2.3 | A fantasia é reconhecível antes do brief | O que a pessoa faz e vê nos primeiros 60s | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-1.1 | Verbo central nomeado e jogável | GDD + uma partida curta | GDD-M | não executado | |
+| CHK-1.2 | A escolha muda estado, rota, recurso ou expectativa | Alternativa A vs. B no mesmo cenário | GDD-M / MDA | não executado | |
+| CHK-1.3 | O risco é legível **antes** da punição | Informação no momento da ação | GDD-M | não executado | |
+| CHK-1.4 | Recusa distinta de sucesso (estado e feedback) | Recurso, alvo inválido, após término | GDD-M / mechanics | não executado | |
+| CHK-1.5 | Sem opção sempre dominante, ou isso é decisão explícita | Duas alternativas | MDA | não executado | |
+| CHK-1.6 | Término e reinício do ciclo definidos e jogáveis | Vitória, derrota, saída, repeat | GDD / lifecycle | não executado | |
 
-## 3. Controle e câmera — CHK-3
+### 2. Primeiro minuto — CHK-2 · núcleo
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-3.1 | O verbo responde no dispositivo alvo (teclado / toque / gamepad) | Mesma ação em cada entrada prometida | não executado | |
-| CHK-3.2 | Buffer, deadzone, cancelamento e perda de foco foram exercitados | Alt-tab, gesto abortado, reconexão | não executado | |
-| CHK-3.3 | Câmera antecipa curva/ameaça sem ocluir o jogador nem enjoar | Percurso real, não still | não executado | |
-| CHK-3.4 | Look-ahead, aterrissagem e punch confirmam a ação e devolvem o controle | Trecho do verbo central | não executado | |
-| CHK-3.5 | Escala e transição de câmera preservam leitura de ameaça e landmark | Zoom, corte, indoor/outdoor se existirem | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-2.1 | A primeira ação ensina o verbo sem mural que bloqueia | Cold start, instrução neutra | GDD | não executado | |
+| CHK-2.2 | Input, frame e câmera do boot sem atraso nem stutter | Movimento nos primeiros segundos | feel / pacing | não executado | |
+| CHK-2.3 | A fantasia é reconhecível antes do brief | O que a pessoa faz e vê ~60s | brief | não executado | |
 
-## 4. Feel sincronizado — CHK-4
+### 4. Feel sincronizado — CHK-4 · núcleo · `--focus feel`
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-4.1 | Intenção: oportunidade e ameaça são legíveis antes do input | Frame anterior à ação | não executado | |
-| CHK-4.2 | Antecipação (pose/frames) promete o golpe/pulo/disparo | Comparar com e sem wind-up | não executado | |
-| CHK-4.3 | Corpo muda silhueta o bastante (squash, recuo, IK, veículo, cursor) | Em movimento | não executado | |
-| CHK-4.4 | Impacto tem peso proporcional (hitstop, flash, partícula, rumble) | Coleta ≠ golpe mortal | não executado | |
-| CHK-4.5 | Flash, hit-pause, shake, partícula e áudio disparam no **mesmo frame** do contato | Gravação quadro a quadro ou observação atenta | não executado | |
-| CHK-4.6 | Recuperação devolve o controle num tempo justo | Encadear a próxima ação | não executado | |
-| CHK-4.7 | Juice não esconde a consequência nem atrasa o próximo input além do ritmo | Silhueta e timing | não executado | |
-| CHK-4.8 | Feel sobrevive a pause, unfocus e restart (sem hitstop/rumble fantasma) | Montar → pausar → retomar; reset | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-4.1 | Intenção: oportunidade e ameaça legíveis antes do input | Frame anterior à ação | feel | não executado | |
+| CHK-4.2 | Antecipação (pose/frames) promete o golpe/pulo/disparo | Com vs. sem wind-up | feel | não executado | |
+| CHK-4.3 | Corpo muda silhueta o bastante | Squash, recuo, IK, veículo, cursor | feel | não executado | |
+| CHK-4.4 | Impacto com peso proporcional | Coleta ≠ golpe mortal | feel | não executado | |
+| CHK-4.5 | Flash, hit-pause, shake, partícula e áudio no **mesmo frame** do contato | Gravação ou observação atenta | feel + audio | não executado | |
+| CHK-4.6 | Recuperação devolve o controle num tempo justo | Encadear a próxima ação | feel | não executado | |
+| CHK-4.7 | Juice não esconde a consequência nem atrasa o próximo input | Silhueta e timing | feel | não executado | |
+| CHK-4.8 | Feel sobrevive a pause, unfocus e restart | Sem hitstop/rumble fantasma | lifecycle | não executado | |
+| CHK-4.9 | Cancelamento ou overlap não deixa o feel preso | Abortar gesto; duas ações seguidas | feel / input | não executado | |
 
-## 5. Áudio e mix — CHK-5
+### 5. Áudio e mix — CHK-5 · núcleo · `--focus audio`
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-5.1 | A ação central se ouve; recusa soa distinta do sucesso | Com som; comparar os dois | não executado | |
-| CHK-5.2 | One-shot de impacto no mesmo frame do hit visual | Sync com CHK-4.5 | não executado | |
-| CHK-5.3 | Camadas (ação, mundo, música, UI, silêncio) têm prioridade; ducking existe | Stinger vs. verbo vs. música | não executado | |
-| CHK-5.4 | Pause, morte, restart, troca de cena e unfocus não deixam voz fantasma | Montar → desmontar → montar | não executado | |
-| CHK-5.5 | O jogo permanece legível no mute, se o recorte exigir acesso ou ruído | Mesmo trecho com mute | não executado | |
-| CHK-5.6 | Piso de gravação licenciada ou direção contemporânea explícita; 8-bit/jsfxr/Kenney não são o padrão | Proveniência do asset | não executado | |
-| CHK-5.7 | Música informa estado (ou a ausência é decisão registrada) | Entrar/sair de combate, menu, morte | não executado | |
-| CHK-5.8 | `shared/sfx` foi buscado antes de baixar, se o laboratório o tiver | Recibo de `sfx search` | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-5.1 | Ação central se ouve; recusa soa distinta | Com som; os dois casos | audio | não executado | |
+| CHK-5.2 | One-shot de impacto no mesmo frame do hit visual | Sync com CHK-4.5 | audio | não executado | |
+| CHK-5.3 | Camadas com prioridade; ducking existe | Stinger vs. verbo vs. música | audio | não executado | |
+| CHK-5.4 | Pause, morte, restart, cena e unfocus sem voz fantasma | Montar → desmontar → montar | lifecycle | não executado | |
+| CHK-5.5 | Legível no mute se o recorte exigir acesso ou ruído | Mesmo trecho mutado | audio / acesso | não executado | |
+| CHK-5.6 | Piso de gravação licenciada ou direção contemporânea explícita | Sem 8-bit/jsfxr/Kenney como padrão | proveniência | não executado | |
+| CHK-5.7 | Música informa estado, ou a ausência é decisão | Combate, menu, morte | audio | não executado | |
+| CHK-5.8 | `sfx search` antes de baixar, se `shared/sfx` existir | Recibo | audio | não executado | |
+| CHK-5.9 | Espacialização só se o jogo já tem espaço; sem HRTF de checklist | 2D/3D real | audio | não executado | |
 
-## 6. Pacing e performance — CHK-6
+### 6. Pacing e performance — CHK-6 · núcleo
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-6.1 | Latência de input é aceitável no dispositivo alvo | Ação repetida; percepção + medição se existir | não executado | |
-| CHK-6.2 | Spikes de frametime no trecho real foram procurados; stutter não é “normal” | Percurso carregado, não menu vazio | não executado | |
-| CHK-6.3 | O piso visual/sonoro aprovado não foi cortado para “ganhar FPS” | Antes/depois; hipótese de eficiência | não executado | |
-| CHK-6.4 | Ambiente da prova está declarado (editor vs. build/export, resolução, plataforma) | Runbook do recorte | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-6.1 | Latência de input aceitável no dispositivo alvo | Ação repetida; medição se existir | feel | não executado | |
+| CHK-6.2 | Spikes de frametime procurados no trecho **carregado** | Não o menu vazio | visual / TDD | não executado | |
+| CHK-6.3 | Piso aprovado não foi cortado para “ganhar FPS” | Antes/depois; hipótese de eficiência | quality | não executado | |
+| CHK-6.4 | Ambiente da prova declarado | Editor vs. export, resolução, plataforma | runbook | não executado | |
+| CHK-6.5 | Se o recorte declara 30/60/120, o feel é equivalente | Mesma ação nas taxas prometidas | TDD / NFR | não executado | |
 
-## 7. Mundo, luz, animação, consistência — CHK-7
+### 11. Ciclo de vida e confiança — CHK-11 · núcleo · `--focus lifecycle`
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-7.1 | Silhueta, material e luz são legíveis **em movimento** | Percurso; não a melhor still | não executado | |
-| CHK-7.2 | Landmark e ameaça distinguem-se sem a cor como único sinal | Formas, movimento, áudio | não executado | |
-| CHK-7.3 | Animação tem antecipação e follow-through no verbo; não está “floaty” | Comparar com referência | não executado | |
-| CHK-7.4 | Família coerente com o asset-herói **no engine**, mesma luz/câmera | Hero comparison in-engine | não executado | |
-| CHK-7.5 | Asset lindo no DCC e errado no jogo foi procurado (integração) | Import real, shader, escala, pivot | não executado | |
-| CHK-7.6 | Um exemplo de “cabe neste jogo” e um de “quebra a direção” existem | Art Bible | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-11.1 | Iniciar, jogar, pausar, perder, ganhar, reiniciar e sair definidos | Cada transição | lifecycle | não executado | |
+| CHK-11.2 | Score, timer, entidade, som, input e progresso batem com o GDD | Pause/reset/load | lifecycle | não executado | |
+| CHK-11.3 | Save (se prometido) não corrompe; dado inválido tratado | Load, save velho, arquivo lixo | content | não executado | |
+| CHK-11.4 | Montar → desmontar → montar sem listener/áudio/GPU duplicado | Dois boots | lifecycle | não executado | |
+| CHK-11.5 | Erro (load, input, rede se houver) fala a verdade | Caminho de falha real | TDD | não executado | |
+| CHK-11.6 | Seed/determinismo só como `observado` se o parâmetro **afeta** o recorte | Repeat + compare; mentioned ≠ verified | lifecycle | não executado | |
 
-## 8. UI, HUD e acesso — CHK-8
+## Produto — escala produto ou AA / Triple-I
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-8.1 | HUD/menus existem e são do jogo, **ou** a ausência é decisão explícita | Art Bible / GDD | não executado | |
-| CHK-8.2 | Contraste e forma além da cor permitem ler estado crítico | Daltonismo, UI em movimento | não executado | |
-| CHK-8.3 | Foco, alvos de toque e movimento reduzido quando o recorte os exige | Dispositivo prometido | não executado | |
-| CHK-8.4 | UI não grita sobre o mundo; não tapa a silhueta da consequência | Mix + layout | não executado | |
-| CHK-8.5 | Navegação de menu sobrevive a pause, erro e volta ao jogo | Ida e volta | não executado | |
+`N/A` com a escala num jam, salvo se o brief prometeu câmera, mundo ou HUD.
 
-## 9. Narrativa e cinemática — CHK-9
+### 3. Controle e câmera — CHK-3 · produto
 
-`N/A` se o recorte não promete história, voz ou cutscene. Se o marketing
-promete imersão cinematográfica, estes itens tornam-se aplicáveis.
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-3.1 | O verbo responde em cada entrada prometida | Teclado / toque / gamepad | GDD | não executado | |
+| CHK-3.2 | Buffer, deadzone, cancelamento e perda de foco exercitados | Alt-tab, gesto abortado | feel | não executado | |
+| CHK-3.3 | Câmera antecipa ameaça sem ocluir nem enjoar | Percurso real | visual | não executado | |
+| CHK-3.4 | Look-ahead, aterrissagem e punch confirmam e devolvem o controle | Verbo central | feel | não executado | |
+| CHK-3.5 | Escala e transição preservam landmark e ameaça | Zoom, corte, indoor/outdoor | visual | não executado | |
+| CHK-3.6 | Rumble/haptic é elo do feel ou decisão explícita de não ter | Impacto vs. UI | feel | não executado | |
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-9.1 | História/escolha tem consequência jogável, não só texto | Caminho alternativo | não executado | |
-| CHK-9.2 | Voz, lip-sync e tom são consistentes (estilização ok; costura entre equipes não) | Cena representativa | não executado | |
-| CHK-9.3 | Corte/câmera de cena não rouba o verbo nem contradiz o feel | Transição jogo ↔ cena | não executado | |
-| CHK-9.4 | Save/histórico narrativo restaura o que o GDD promete | Load no meio da escolha | não executado | |
+### 7. Mundo, luz, animação — CHK-7 · produto · `--focus visual`
 
-## 10. Receita de conteúdo e produção — CHK-10
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-7.1 | Silhueta, material e luz legíveis **em movimento** | Percurso, não still | visual | não executado | |
+| CHK-7.2 | Landmark e ameaça sem a cor como único sinal | Forma, movimento, áudio | visual / acesso | não executado | |
+| CHK-7.3 | Animação com antecipação e follow-through; não “floaty” | Referência em movimento | visual / feel | não executado | |
+| CHK-7.4 | Família coerente com o herói **no engine**, mesma luz/câmera | Hero comparison | art-bible | não executado | |
+| CHK-7.5 | Asset lindo no DCC e errado no jogo foi procurado | Shader, escala, pivot | content | não executado | |
+| CHK-7.6 | Um “cabe neste jogo” e um “quebra a direção” | Art Bible | art-bible | não executado | |
+| CHK-7.7 | Luz serve à leitura; mood não apaga ameaça nem landmark | Trecho escuro/claro | visual | não executado | |
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-10.1 | Existe receita para o próximo item da família (inimigo, sala, efeito) | Art Bible / GDD | não executado | |
-| CHK-10.2 | A slice usou o **pipeline real**, não um atalho irrepetível | Ferramenta, import, naming | não executado | |
-| CHK-10.3 | Custo observado do próximo trecho está registrado | Tempo/esforço medido, não chute | não executado | |
-| CHK-10.4 | Repeatability: outro trecho nasce sem heroísmo | Quatro eixos: valor, técnica, produção, clareza | não executado | |
-| CHK-10.5 | Tokens têm consumidor real; arquivo órfão não conta | Path do uso | não executado | |
+### 8. UI, HUD e acesso — CHK-8 · produto
 
-## 11. Ciclo de vida e confiança — CHK-11
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-8.1 | HUD/menus do jogo, **ou** decisão explícita de não ter | Art Bible / GDD | art-bible | não executado | |
+| CHK-8.2 | Contraste e forma além da cor no estado crítico | Daltonismo, UI em movimento | acesso | não executado | |
+| CHK-8.3 | Foco, alvos de toque e movimento reduzido se o recorte os exige | Dispositivo prometido | acesso | não executado | |
+| CHK-8.4 | UI não grita sobre o mundo nem tapa a consequência | Mix + layout | audio / visual | não executado | |
+| CHK-8.5 | Menu sobrevive a pause, erro e volta ao jogo | Ida e volta | lifecycle | não executado | |
+| CHK-8.6 | Fotossensibilidade: flashes do feel não viram strobe contínuo | CHK-4.5 sob movimento reduzido | acesso / feel | não executado | |
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-11.1 | Iniciar, jogar, pausar, perder, ganhar, reiniciar e sair têm consequência definida | Cada transição uma vez | não executado | |
-| CHK-11.2 | Score, timer, entidade, som, input e progresso sobrevivem ou zeram como o GDD diz | Pause/reset/load | não executado | |
-| CHK-11.3 | Save (se prometido) não corrompe; migração/dado inválido está tratado | Load, save velho, arquivo lixo | não executado | |
-| CHK-11.4 | Descarte: montar → desmontar → montar sem listener/áudio/GPU duplicado | Dois boots seguidos | não executado | |
-| CHK-11.5 | Erro (falha de load, input, rede se houver) fala a verdade ao jogador | Caminho de falha real | não executado | |
+### 10. Receita e produção — CHK-10 · produto
 
-## 12. Rede — CHK-12
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-10.1 | Receita do próximo item da família | Art Bible / GDD | art-bible | não executado | |
+| CHK-10.2 | A slice usou o **pipeline real**, não atalho irrepetível | Ferramenta, import, naming | TDD | não executado | |
+| CHK-10.3 | Custo observado do próximo trecho | Medido, não chute | slice | não executado | |
+| CHK-10.4 | Repeatability: outro trecho sem heroísmo | Valor, técnica, produção, clareza | slice | não executado | |
+| CHK-10.5 | Tokens com consumidor real | Path do uso | art-bible | não executado | |
+| CHK-10.6 | Gate de import (nome, escala, pivot) antes de multiplicar | Um asset novo pela receita | content | não executado | |
 
-`N/A` se o recorte é local / um jogador sem estado compartilhado.
+### 14. QA e evidência — CHK-14 · produto · `--stage qa`
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-12.1 | Quem aceita a ação e quem decide o estado está explícito | Duas sessões reais | não executado | |
-| CHK-12.2 | Ação recusada no autoritativo, não só na UI | Cliente desonesto ou replay | não executado | |
-| CHK-12.3 | Entrada, saída, desconexão e reconexão foram exercitadas | Duas sessões | não executado | |
-| CHK-12.4 | Mensagem duplicada, atrasada ou fora de ordem não quebra o recorte | Quando o protocolo permite | não executado | |
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-14.1 | Casos técnicos com comando real e recibo | `verify`; inspect antes | qa | não executado | |
+| CHK-14.2 | Playtest de pessoa ≠ avaliação do agente | Relato literal vs. interpretação | qa | não executado | |
+| CHK-14.3 | Antes/depois em condições equivalentes, em movimento | Versão, resolução, entrada, trecho | quality | não executado | |
+| CHK-14.4 | `experience_status` = `not_assessed` até haver movimento | Recibo de verify | verify | não executado | |
 
-## 13. Localização — CHK-13
+### 15. Origem e direitos — CHK-15 · produto
 
-`N/A` se o recorte não promete outro idioma. Promessa de público amplo
-torna o item aplicável.
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-15.1 | Código e assets do recorte com origem, crédito e uso | CREDITS | provenance | não executado | |
+| CHK-15.2 | Nenhuma licença inventada pela pasta | Baixado / gerado | provenance | não executado | |
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-13.1 | Textos do recorte não estão hardcoded sem gancho de locale | UI + diálogo do trecho | não executado | |
-| CHK-13.2 | Overflow, fonte e leitura funcionam no idioma alvo (ou a lacuna está explícita) | Idioma mais longo se houver | não executado | |
+## Promessa — só se o brief prometeu
 
-## 14. QA, playtest e evidência — CHK-14
+### 9. Narrativa e cinemática — CHK-9 · promessa
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-14.1 | Casos técnicos do recorte têm comando real e recibo (`verify` ou equivalente) | Logs; inspect antes de rodar | não executado | |
-| CHK-14.2 | Playtest (pessoa) e avaliação do agente estão separados | Relato literal vs. interpretação | não executado | |
-| CHK-14.3 | Comparação antes/depois em condições equivalentes, em movimento | Versão, resolução, entrada, trecho | não executado | |
-| CHK-14.4 | `experience_status` permanece `not_assessed` até haver observação em movimento | Recibo de verify | não executado | |
+`N/A` sem história, voz ou cutscene. Marketing cinematográfico torna aplicável.
 
-## 15. Origem e direitos — CHK-15
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-9.1 | Escolha com consequência jogável, não só texto | Caminho alternativo | GDD / content | não executado | |
+| CHK-9.2 | Voz, lip-sync e tom consistentes | Cena representativa | art-bible | não executado | |
+| CHK-9.3 | Corte de cena não rouba o verbo nem o feel | Transição jogo ↔ cena | feel | não executado | |
+| CHK-9.4 | Save/histórico restaura o que o GDD promete | Load no meio da escolha | content | não executado | |
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-15.1 | Código e assets do recorte têm origem, crédito e condição de uso | CREDITS / proveniência | não executado | |
-| CHK-15.2 | Nada recebeu licença inventada pela pasta em que está | Arquivo baixado / gerado | não executado | |
+### 12. Rede — CHK-12 · promessa · `--focus network`
 
-## 16. Tier de mercado (contexto, não piso) — CHK-16
+`N/A` se for local, sem estado compartilhado.
 
-Todos começam `N/A` salvo se o projeto **for** desse tier. Não usar para
-reprovar um conto ou um AA / Triple-I.
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-12.1 | Quem aceita a ação e quem decide o estado | Duas sessões reais | network | não executado | |
+| CHK-12.2 | Recusa no autoritativo, não só na UI | Cliente desonesto ou replay | network | não executado | |
+| CHK-12.3 | Entrada, saída, desconexão e reconexão | Duas sessões | network | não executado | |
+| CHK-12.4 | Duplicata, atraso ou fora de ordem não quebra o recorte | Se o protocolo permite | network | não executado | |
 
-| ID | Item | Como observar | Estado | Evidência / lacuna |
-| --- | --- | --- | --- | --- |
-| CHK-16.1 | Publisher, orçamento e headcount reais (se existirem) | Fato, não meta | N/A | Não é condição do piso. |
-| CHK-16.2 | Live ops / temporada / microtransação | Só se o produto as tiver | N/A | Não inventar. |
-| CHK-16.3 | Certificação de console / XR / BVT | Só se houver submissão | N/A | Não é selo de acabamento. |
-| CHK-16.4 | Marketing blockbuster, celebridade, AAAA | Só como contexto | N/A | Buzzword; sem definição. |
+### 13. Localização — CHK-13 · promessa
+
+`N/A` sem outro idioma. Público amplo declarado torna aplicável.
+
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-13.1 | Textos do recorte com gancho de locale | UI + diálogo | content | não executado | |
+| CHK-13.2 | Overflow e leitura no idioma alvo, ou lacuna explícita | Idioma mais longo | content | não executado | |
+
+## Mercado — contexto, nunca piso
+
+### 16. Tier de publisher — CHK-16 · mercado
+
+Começa `N/A`. Não reprova conto nem AA / Triple-I.
+
+| ID | Item | Observar | Origem | Estado | Evidência |
+| --- | --- | --- | --- | --- | --- |
+| CHK-16.1 | Publisher, orçamento e headcount **reais** | Fato, não meta | — | N/A | Não é condição do piso. |
+| CHK-16.2 | Live ops / temporada / microtransação | Só se o produto as tiver | — | N/A | Não inventar. |
+| CHK-16.3 | Certificação de console / XR / BVT | Só se houver submissão | — | N/A | Não é selo de acabamento. |
+| CHK-16.4 | Marketing blockbuster, celebridade, AAAA | Só contexto | — | N/A | Buzzword; sem definição. |
 
 ## Resumo do recorte
 
-- Aplicáveis observados: [IDs].
-- Aplicáveis inconclusivos: [IDs].
-- Aplicáveis não executados: [IDs].
-- N/A com motivo: [IDs].
-- **O que ainda impede chamar isto de piso de acabamento:** [IDs materiais].
+- Perfil usado: [núcleo · núcleo+produto · +promessas].
+- Núcleo observado / inconclusivo / não executado: [IDs].
+- Produto e promessa: [IDs ou N/A].
+- **O que ainda impede o adjetivo no perfil em vigor:** [IDs materiais].
 - Próxima ação (uma): [verbo, alvo, prova].
-- Aprovação do usuário: [somente se concedida; senão, avaliação do agente].
+- Aprovação do usuário: [somente se concedida].

--- a/assets/templates/aaa.md
+++ b/assets/templates/aaa.md
@@ -1,0 +1,202 @@
+# Checklist de piso de acabamento — {{PROJECT}}
+
+Projeto: {{PROJECT_PATH}}
+Status: rascunho. Preencher este arquivo **não** certifica AAA de publisher,
+não mede diversão e não autoriza publicar. “AAA” = piso da fatia observada.
+Contrato: `framework/references/ambition.md` e
+`framework/references/aaa-checklist.md`.
+
+- Escala: [jam/conto · produto · AA / Triple-I].
+- Recorte observado: [slice / capítulo / verbo; o que está fora].
+- Promessas do recorte: [cinemática, HUD, save, rede, localização, acesso…].
+- Referência aprovada: [localizador, quem aprovou, o que não cobre].
+- Observador / data / versão / dispositivo / entrada: [preencher].
+- Legenda: `não executado` · `observado` · `inconclusivo` · `N/A` (motivo).
+
+Não some linhas. Screenshot isolada não fecha feel, animação, câmera, mix
+nem pacing. N/A exige motivo. Vermelho material bloqueia o adjetivo.
+
+## 0. Contrato — CHK-0
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-0.1 | Escala e recorte estão explícitos; o adjetivo “AAA” não foi usado sem as barras | Brief/slice; busca pelo adjetivo no recorte | não executado | |
+| CHK-0.2 | Direção aprovada tem alcance; o que ela não cobre está escrito | Art Bible / conversa; mock ≠ mecânica | não executado | |
+| CHK-0.3 | Scaffold, PoC e slice não estão confundidos | Nome do build vs. comportamento | não executado | |
+| CHK-0.4 | Itens não prometidos estão `N/A` com motivo; nada foi inventado para “completar AAA” | Rede, live ops, localização, mocap… | não executado | |
+
+## 1. Verbo e decisão — CHK-1
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-1.1 | Há um verbo central nomeado e jogável | GDD + uma partida curta | não executado | |
+| CHK-1.2 | A escolha muda estado, rota, recurso ou expectativa | Alternativa A vs. B no mesmo cenário | não executado | |
+| CHK-1.3 | O risco é legível **antes** da punição | Informação disponível no momento da ação | não executado | |
+| CHK-1.4 | Recusa é distinta de sucesso (estado e feedback) | Recurso insuficiente, alvo inválido, após término | não executado | |
+| CHK-1.5 | Não há opção sempre dominante no recorte, ou isso é decisão explícita | Duas alternativas sob o mesmo cenário | não executado | |
+| CHK-1.6 | Término e reinício do ciclo estão definidos e jogáveis | Vitória, derrota, saída, repeat | não executado | |
+
+## 2. Primeiro minuto — CHK-2
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-2.1 | A primeira ação ensina o verbo sem mural que bloqueia o jogo | Cold start, instrução neutra | não executado | |
+| CHK-2.2 | Input, frame e câmera do primeiro minuto não denunciam atraso nem stutter | Observação em movimento no boot | não executado | |
+| CHK-2.3 | A fantasia é reconhecível antes do brief | O que a pessoa faz e vê nos primeiros 60s | não executado | |
+
+## 3. Controle e câmera — CHK-3
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-3.1 | O verbo responde no dispositivo alvo (teclado / toque / gamepad) | Mesma ação em cada entrada prometida | não executado | |
+| CHK-3.2 | Buffer, deadzone, cancelamento e perda de foco foram exercitados | Alt-tab, gesto abortado, reconexão | não executado | |
+| CHK-3.3 | Câmera antecipa curva/ameaça sem ocluir o jogador nem enjoar | Percurso real, não still | não executado | |
+| CHK-3.4 | Look-ahead, aterrissagem e punch confirmam a ação e devolvem o controle | Trecho do verbo central | não executado | |
+| CHK-3.5 | Escala e transição de câmera preservam leitura de ameaça e landmark | Zoom, corte, indoor/outdoor se existirem | não executado | |
+
+## 4. Feel sincronizado — CHK-4
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-4.1 | Intenção: oportunidade e ameaça são legíveis antes do input | Frame anterior à ação | não executado | |
+| CHK-4.2 | Antecipação (pose/frames) promete o golpe/pulo/disparo | Comparar com e sem wind-up | não executado | |
+| CHK-4.3 | Corpo muda silhueta o bastante (squash, recuo, IK, veículo, cursor) | Em movimento | não executado | |
+| CHK-4.4 | Impacto tem peso proporcional (hitstop, flash, partícula, rumble) | Coleta ≠ golpe mortal | não executado | |
+| CHK-4.5 | Flash, hit-pause, shake, partícula e áudio disparam no **mesmo frame** do contato | Gravação quadro a quadro ou observação atenta | não executado | |
+| CHK-4.6 | Recuperação devolve o controle num tempo justo | Encadear a próxima ação | não executado | |
+| CHK-4.7 | Juice não esconde a consequência nem atrasa o próximo input além do ritmo | Silhueta e timing | não executado | |
+| CHK-4.8 | Feel sobrevive a pause, unfocus e restart (sem hitstop/rumble fantasma) | Montar → pausar → retomar; reset | não executado | |
+
+## 5. Áudio e mix — CHK-5
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-5.1 | A ação central se ouve; recusa soa distinta do sucesso | Com som; comparar os dois | não executado | |
+| CHK-5.2 | One-shot de impacto no mesmo frame do hit visual | Sync com CHK-4.5 | não executado | |
+| CHK-5.3 | Camadas (ação, mundo, música, UI, silêncio) têm prioridade; ducking existe | Stinger vs. verbo vs. música | não executado | |
+| CHK-5.4 | Pause, morte, restart, troca de cena e unfocus não deixam voz fantasma | Montar → desmontar → montar | não executado | |
+| CHK-5.5 | O jogo permanece legível no mute, se o recorte exigir acesso ou ruído | Mesmo trecho com mute | não executado | |
+| CHK-5.6 | Piso de gravação licenciada ou direção contemporânea explícita; 8-bit/jsfxr/Kenney não são o padrão | Proveniência do asset | não executado | |
+| CHK-5.7 | Música informa estado (ou a ausência é decisão registrada) | Entrar/sair de combate, menu, morte | não executado | |
+| CHK-5.8 | `shared/sfx` foi buscado antes de baixar, se o laboratório o tiver | Recibo de `sfx search` | não executado | |
+
+## 6. Pacing e performance — CHK-6
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-6.1 | Latência de input é aceitável no dispositivo alvo | Ação repetida; percepção + medição se existir | não executado | |
+| CHK-6.2 | Spikes de frametime no trecho real foram procurados; stutter não é “normal” | Percurso carregado, não menu vazio | não executado | |
+| CHK-6.3 | O piso visual/sonoro aprovado não foi cortado para “ganhar FPS” | Antes/depois; hipótese de eficiência | não executado | |
+| CHK-6.4 | Ambiente da prova está declarado (editor vs. build/export, resolução, plataforma) | Runbook do recorte | não executado | |
+
+## 7. Mundo, luz, animação, consistência — CHK-7
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-7.1 | Silhueta, material e luz são legíveis **em movimento** | Percurso; não a melhor still | não executado | |
+| CHK-7.2 | Landmark e ameaça distinguem-se sem a cor como único sinal | Formas, movimento, áudio | não executado | |
+| CHK-7.3 | Animação tem antecipação e follow-through no verbo; não está “floaty” | Comparar com referência | não executado | |
+| CHK-7.4 | Família coerente com o asset-herói **no engine**, mesma luz/câmera | Hero comparison in-engine | não executado | |
+| CHK-7.5 | Asset lindo no DCC e errado no jogo foi procurado (integração) | Import real, shader, escala, pivot | não executado | |
+| CHK-7.6 | Um exemplo de “cabe neste jogo” e um de “quebra a direção” existem | Art Bible | não executado | |
+
+## 8. UI, HUD e acesso — CHK-8
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-8.1 | HUD/menus existem e são do jogo, **ou** a ausência é decisão explícita | Art Bible / GDD | não executado | |
+| CHK-8.2 | Contraste e forma além da cor permitem ler estado crítico | Daltonismo, UI em movimento | não executado | |
+| CHK-8.3 | Foco, alvos de toque e movimento reduzido quando o recorte os exige | Dispositivo prometido | não executado | |
+| CHK-8.4 | UI não grita sobre o mundo; não tapa a silhueta da consequência | Mix + layout | não executado | |
+| CHK-8.5 | Navegação de menu sobrevive a pause, erro e volta ao jogo | Ida e volta | não executado | |
+
+## 9. Narrativa e cinemática — CHK-9
+
+`N/A` se o recorte não promete história, voz ou cutscene. Se o marketing
+promete imersão cinematográfica, estes itens tornam-se aplicáveis.
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-9.1 | História/escolha tem consequência jogável, não só texto | Caminho alternativo | não executado | |
+| CHK-9.2 | Voz, lip-sync e tom são consistentes (estilização ok; costura entre equipes não) | Cena representativa | não executado | |
+| CHK-9.3 | Corte/câmera de cena não rouba o verbo nem contradiz o feel | Transição jogo ↔ cena | não executado | |
+| CHK-9.4 | Save/histórico narrativo restaura o que o GDD promete | Load no meio da escolha | não executado | |
+
+## 10. Receita de conteúdo e produção — CHK-10
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-10.1 | Existe receita para o próximo item da família (inimigo, sala, efeito) | Art Bible / GDD | não executado | |
+| CHK-10.2 | A slice usou o **pipeline real**, não um atalho irrepetível | Ferramenta, import, naming | não executado | |
+| CHK-10.3 | Custo observado do próximo trecho está registrado | Tempo/esforço medido, não chute | não executado | |
+| CHK-10.4 | Repeatability: outro trecho nasce sem heroísmo | Quatro eixos: valor, técnica, produção, clareza | não executado | |
+| CHK-10.5 | Tokens têm consumidor real; arquivo órfão não conta | Path do uso | não executado | |
+
+## 11. Ciclo de vida e confiança — CHK-11
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-11.1 | Iniciar, jogar, pausar, perder, ganhar, reiniciar e sair têm consequência definida | Cada transição uma vez | não executado | |
+| CHK-11.2 | Score, timer, entidade, som, input e progresso sobrevivem ou zeram como o GDD diz | Pause/reset/load | não executado | |
+| CHK-11.3 | Save (se prometido) não corrompe; migração/dado inválido está tratado | Load, save velho, arquivo lixo | não executado | |
+| CHK-11.4 | Descarte: montar → desmontar → montar sem listener/áudio/GPU duplicado | Dois boots seguidos | não executado | |
+| CHK-11.5 | Erro (falha de load, input, rede se houver) fala a verdade ao jogador | Caminho de falha real | não executado | |
+
+## 12. Rede — CHK-12
+
+`N/A` se o recorte é local / um jogador sem estado compartilhado.
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-12.1 | Quem aceita a ação e quem decide o estado está explícito | Duas sessões reais | não executado | |
+| CHK-12.2 | Ação recusada no autoritativo, não só na UI | Cliente desonesto ou replay | não executado | |
+| CHK-12.3 | Entrada, saída, desconexão e reconexão foram exercitadas | Duas sessões | não executado | |
+| CHK-12.4 | Mensagem duplicada, atrasada ou fora de ordem não quebra o recorte | Quando o protocolo permite | não executado | |
+
+## 13. Localização — CHK-13
+
+`N/A` se o recorte não promete outro idioma. Promessa de público amplo
+torna o item aplicável.
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-13.1 | Textos do recorte não estão hardcoded sem gancho de locale | UI + diálogo do trecho | não executado | |
+| CHK-13.2 | Overflow, fonte e leitura funcionam no idioma alvo (ou a lacuna está explícita) | Idioma mais longo se houver | não executado | |
+
+## 14. QA, playtest e evidência — CHK-14
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-14.1 | Casos técnicos do recorte têm comando real e recibo (`verify` ou equivalente) | Logs; inspect antes de rodar | não executado | |
+| CHK-14.2 | Playtest (pessoa) e avaliação do agente estão separados | Relato literal vs. interpretação | não executado | |
+| CHK-14.3 | Comparação antes/depois em condições equivalentes, em movimento | Versão, resolução, entrada, trecho | não executado | |
+| CHK-14.4 | `experience_status` permanece `not_assessed` até haver observação em movimento | Recibo de verify | não executado | |
+
+## 15. Origem e direitos — CHK-15
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-15.1 | Código e assets do recorte têm origem, crédito e condição de uso | CREDITS / proveniência | não executado | |
+| CHK-15.2 | Nada recebeu licença inventada pela pasta em que está | Arquivo baixado / gerado | não executado | |
+
+## 16. Tier de mercado (contexto, não piso) — CHK-16
+
+Todos começam `N/A` salvo se o projeto **for** desse tier. Não usar para
+reprovar um conto ou um AA / Triple-I.
+
+| ID | Item | Como observar | Estado | Evidência / lacuna |
+| --- | --- | --- | --- | --- |
+| CHK-16.1 | Publisher, orçamento e headcount reais (se existirem) | Fato, não meta | N/A | Não é condição do piso. |
+| CHK-16.2 | Live ops / temporada / microtransação | Só se o produto as tiver | N/A | Não inventar. |
+| CHK-16.3 | Certificação de console / XR / BVT | Só se houver submissão | N/A | Não é selo de acabamento. |
+| CHK-16.4 | Marketing blockbuster, celebridade, AAAA | Só como contexto | N/A | Buzzword; sem definição. |
+
+## Resumo do recorte
+
+- Aplicáveis observados: [IDs].
+- Aplicáveis inconclusivos: [IDs].
+- Aplicáveis não executados: [IDs].
+- N/A com motivo: [IDs].
+- **O que ainda impede chamar isto de piso de acabamento:** [IDs materiais].
+- Próxima ação (uma): [verbo, alvo, prova].
+- Aprovação do usuário: [somente se concedida; senão, avaliação do agente].

--- a/assets/templates/art-bible.md
+++ b/assets/templates/art-bible.md
@@ -60,4 +60,5 @@ existentes. Jogo sem HUD registra essa escolha, sem inventar biblioteca de UI.]
 - Lacunas: [visual, som, feel, mix, acesso, origem ou consumo ainda não demonstrados].
 - Decisão REUSE/ADAPT/CREATE e próximo passo: [fontes, motivo e alcance].
 - Performance: [custo observado e hipótese de eficiência; sem degradar o piso aprovado].
-- Escala: [jam / produto / AAA-shaped; a slice precisa demonstrar o piso escolhido].
+- Escala: [jam / produto / AA–Triple-I; a slice precisa demonstrar o piso escolhido].
+  “AAA” não é adjetivo do build.

--- a/assets/templates/art-bible.md
+++ b/assets/templates/art-bible.md
@@ -29,8 +29,15 @@ e consumidores. Diferencie observado, inferido, proposto e ainda não examinado.
 
 ## Feel e feedback
 
-[Sinal da ação central: hitstop, câmera, squash, partículas, rumble, stinger,
-silêncio. Ligue ao verbo do GDD. Jogo sem juice declara essa escolha.]
+[Sinal da ação central: intenção, input, antecipação, corpo, impacto, câmera,
+áudio, recuperação. Hitstop, squash, partículas, rumble, stinger. Ligue ao
+verbo do GDD. Jogo sem juice declara essa escolha.]
+
+## Áudio e mix
+
+[Papéis: ação/Foley, mundo, música, stinger, silêncio. Consumidor real (evento,
+bus, cena). Ducking, interrupção em pause/reset, descarte. Piso de gravação
+licenciada salvo direção explícita. Arquivo sem consumidor não é token ativo.]
 
 ## UI, HUD e acesso
 
@@ -50,6 +57,7 @@ existentes. Jogo sem HUD registra essa escolha, sem inventar biblioteca de UI.]
 
 - Cenário de comparação em movimento: [referência e condições equivalentes].
 - Observação realizada: [evidência e autor; não presumir aprovação do usuário].
-- Lacunas: [visual, som, feel, acesso, origem ou consumo ainda não demonstrados].
+- Lacunas: [visual, som, feel, mix, acesso, origem ou consumo ainda não demonstrados].
 - Decisão REUSE/ADAPT/CREATE e próximo passo: [fontes, motivo e alcance].
 - Performance: [custo observado e hipótese de eficiência; sem degradar o piso aprovado].
+- Escala: [jam / produto / AAA-shaped; a slice precisa demonstrar o piso escolhido].

--- a/assets/templates/brief.md
+++ b/assets/templates/brief.md
@@ -26,7 +26,10 @@ Fonte canônica anterior e direção do usuário: [localizar; adaptar se já exi
 
 ## Primeiro recorte e incertezas
 
+- Escala de ambição: [jam/conto · produto · AAA-shaped]. Quantidade de artefatos
+  e de conteúdo segue a escala; o piso do verbo não. Ver `framework/references/ambition.md`.
 - Primeira situação jogável: [ação, decisão, consequência e reinício].
+- Feel e áudio desse verbo: [o que deve ser percebido no primeiro ciclo; lacuna se ainda for PoC].
 - Escopo essencial e adiado: [limites e motivos, respeitando exigências do usuário].
 - Hipótese mais arriscada: [o que pode invalidar a experiência].
 - Experimento inicial: [como descobrir; limite de esforço e critério de parada].

--- a/assets/templates/brief.md
+++ b/assets/templates/brief.md
@@ -26,8 +26,9 @@ Fonte canônica anterior e direção do usuário: [localizar; adaptar se já exi
 
 ## Primeiro recorte e incertezas
 
-- Escala de ambição: [jam/conto · produto · AAA-shaped]. Quantidade de artefatos
-  e de conteúdo segue a escala; o piso do verbo não. Ver `framework/references/ambition.md`.
+- Escala de ambição: [jam/conto · produto · AA / Triple-I (piso de acabamento)].
+  Quantidade de artefatos e de conteúdo segue a escala; o piso do verbo não.
+  “AAA” não é adjetivo do build. Ver `framework/references/ambition.md`.
 - Primeira situação jogável: [ação, decisão, consequência e reinício].
 - Feel e áudio desse verbo: [o que deve ser percebido no primeiro ciclo; lacuna se ainda for PoC].
 - Escopo essencial e adiado: [limites e motivos, respeitando exigências do usuário].

--- a/assets/templates/gdd.md
+++ b/assets/templates/gdd.md
@@ -25,10 +25,12 @@ Adapte seções ao gênero; registre por que uma dimensão material não se apli
 - Reuso: [candidato, consumidor, decisão e lacuna].
 - Situação para experimentar: [cenário, variante e observação desejada].
 
-## Controles, câmera e legibilidade
+## Controles, câmera e feel
 
 [Verbo central por dispositivo, resposta, orientação, enquadramento, cancelamento,
-perda de foco e necessidades de acesso. Explicite diferenças entre entradas.]
+perda de foco e necessidades de acesso. Explicite diferenças entre entradas.
+Cadeia de feel: intenção → input → antecipação → corpo → impacto → câmera →
+áudio → recuperação. O que confirma o verbo e o que seria juice que o esconde.]
 
 ## Ritmo, progressão e equilíbrio
 
@@ -45,8 +47,14 @@ ou documento narrativo apenas quando o volume justificar.]
 ## Direção visual e sonora
 
 [Referências, origem/aprovação, silhuetas, escala, materiais, iluminação, efeitos,
-animação, música e feedback pertinentes. Defina a comparação em movimento e preserve
-a qualidade aprovada. Uma bíblia de arte pode ser separada se necessária.]
+animação, música e feedback pertinentes. Mix: camadas, ducking, interrupção e
+silêncio. Defina a comparação em movimento e preserve a qualidade aprovada.
+Uma bíblia de arte pode ser separada se necessária.]
+
+## Primeiro minuto
+
+[Como a primeira ação ensina o verbo. O que a pessoa faz antes de ler. O que
+não será um mural de texto. Acesso: contraste, forma além da cor, toque.]
 
 ## Estado e persistência
 

--- a/assets/templates/prd.md
+++ b/assets/templates/prd.md
@@ -24,10 +24,12 @@ restrições explícitas do usuário. Referencie a experiência canônica sem co
 
 ## Requisito de qualidade — NFR-001
 
-- Dimensão e origem: [acessibilidade, confiabilidade, controle, integração ou outra necessidade real].
+- Dimensão e origem: [feel, mix, acesso, confiabilidade, controle, integração
+  ou outra necessidade real do recorte].
 - Condições e resultado esperado: [dispositivo/cenário/critério; números apenas com fundamento].
-- Método de observação: [procedimento, referência e limite da prova].
-- Restrição: preservar a qualidade visual aprovada; metas de performance não autorizam cortes perceptíveis.
+- Método de observação: [procedimento, referência em movimento e limite da prova].
+- Restrição: preservar a qualidade visual e sonora aprovada; metas de
+  performance não autorizam cortes perceptíveis de feel, luz, animação ou mix.
 
 ## Fronteira do MVP e sucesso
 

--- a/assets/templates/qa.md
+++ b/assets/templates/qa.md
@@ -21,9 +21,11 @@ Versão/arquivos, ambiente e referência: [localizadores e limites de identifica
 
 ## Caso de feel / áudio — QA-002
 
-- Elo ou camada: [impacto, câmera, ducking, interrupção, silêncio…].
+- Elo ou camada: [impacto, câmera, ducking, interrupção, silêncio, pacing…].
 - Condição equivalente: [versão, entrada, trecho; mute on/off quando couber].
-- Esperado percebido: [duração, peso, prioridade; sem screenshot isolada].
+- Esperado percebido: [duração, peso, prioridade; flash/hit-pause/áudio no mesmo
+  frame; sem screenshot isolada].
+- Pacing: [latência e spikes de frametime no trecho; não negociar o piso por FPS].
 - Resultado: não executado.
 - Julgamento: [agente ou pessoa; não confundir].
 

--- a/assets/templates/qa.md
+++ b/assets/templates/qa.md
@@ -19,6 +19,14 @@ Versão/arquivos, ambiente e referência: [localizadores e limites de identifica
 - Resultado: não executado.
 - Evidência e versão: [log/estado/captura e limite do que comprovam].
 
+## Caso de feel / áudio — QA-002
+
+- Elo ou camada: [impacto, câmera, ducking, interrupção, silêncio…].
+- Condição equivalente: [versão, entrada, trecho; mute on/off quando couber].
+- Esperado percebido: [duração, peso, prioridade; sem screenshot isolada].
+- Resultado: não executado.
+- Julgamento: [agente ou pessoa; não confundir].
+
 ## Playtest — PLAY-001
 
 - Hipótese: [compreensão, decisão, controle, ritmo ou experiência].

--- a/assets/templates/qa.md
+++ b/assets/templates/qa.md
@@ -49,6 +49,12 @@ Versão/arquivos, ambiente e referência: [localizadores e limites de identifica
 - Reteste: [caso, nova versão e resultado observado].
 - Comparação visual: [antes/depois em movimento; avaliação técnica não substitui julgamento].
 
+## Ligação ao piso
+
+- Perfil `finish`: [núcleo · +produto · +promessas].
+- IDs CHK observados / em aberto: [ligar a QA-00x / PLAY-00x].
+- O adjetivo “AAA” continua bloqueado se o núcleo material estiver aberto.
+
 ## Conclusão do escopo
 
 - Requisitos cobertos e pendentes: [IDs com evidência; não apenas contagem de testes].

--- a/assets/templates/vertical-slice.md
+++ b/assets/templates/vertical-slice.md
@@ -46,6 +46,7 @@ Fontes canônicas: [GDD, PRD, TDD e experimentos anteriores].
 
 - O recorte demonstra o padrão de experiência/acabamento pretendido? [evidência e autor do julgamento].
 - Feel/áudio sincronizados no impacto e pacing estável no trecho? [observação].
+- Checklist de piso (`aaa`): [IDs materiais ainda abertos; N/A com motivo].
 - O processo para produzir outro trecho está compreendido? [custo observado e dificuldade].
 - Limites: [o que esse recorte ainda não prova sobre o jogo completo].
 - Próxima fatia: [resultado, requisitos, dependências e prova].

--- a/assets/templates/vertical-slice.md
+++ b/assets/templates/vertical-slice.md
@@ -14,11 +14,15 @@ Fontes canônicas: [GDD, PRD, TDD e experimentos anteriores].
 ## Integração e acabamento
 
 - Gameplay/estado: [regras, controles, câmera e transições reais].
-- Conteúdo/arte: [assets corretos carregados, escala, materiais e animações].
-- Áudio/feedback: [consequências perceptíveis, interrupção e retomada].
-- Referência visual: [origem, versão e quem aprovou; lacuna explícita se não houver].
+- Feel do verbo: [cadeia perceptível no trecho; o que ainda é placeholder].
+- Conteúdo/arte: [assets corretos carregados, escala, materiais, luz e animações].
+- Áudio/mix: [camadas, ducking, consequências audíveis, interrupção e retomada].
+- Referência visual/sonora: [origem, versão e quem aprovou; lacuna explícita se não houver].
 - Preservações: [qualidades aprovadas que precisam sobreviver ao recorte].
+- Receita de conteúdo: [o próximo item da família nasce como? custo observado].
 - Reuso/adaptação/criação: [fontes e consumidores; o que de fato foi produzido].
+- Escala declarada: [jam / produto / AAA-shaped]. Scaffold ou HUD isolado não
+  certificam a slice.
 
 ## Prova de integração e experiência
 

--- a/assets/templates/vertical-slice.md
+++ b/assets/templates/vertical-slice.md
@@ -21,8 +21,9 @@ Fontes canônicas: [GDD, PRD, TDD e experimentos anteriores].
 - Preservações: [qualidades aprovadas que precisam sobreviver ao recorte].
 - Receita de conteúdo: [o próximo item da família nasce como? custo observado].
 - Reuso/adaptação/criação: [fontes e consumidores; o que de fato foi produzido].
-- Escala declarada: [jam / produto / AAA-shaped]. Scaffold ou HUD isolado não
-  certificam a slice.
+- Escala declarada: [jam / produto / AA–Triple-I]. Scaffold ou HUD isolado não
+  certificam a slice. “AAA” só após as barras abaixo, e mesmo assim significa
+  piso de acabamento, não tier de publisher.
 
 ## Prova de integração e experiência
 
@@ -32,9 +33,19 @@ Fontes canônicas: [GDD, PRD, TDD e experimentos anteriores].
 - Resultados e evidências: não executados.
 - Regressões/pendências: [o que impede avaliar o trecho como representativo].
 
+## Repeatability
+
+- Outro trecho nasce pela receita, sem heroísmo? [sim / não / lacuna; custo observado].
+- Valor para o jogador: [o ciclo ainda vale a segunda sessão? evidência].
+- Viabilidade técnica: [pacing, input, build/export do trecho; limites].
+- Produção repetível: [pipeline real usado, não atalho da slice].
+- Clareza do produto: [a pessoa entende a fantasia sem o brief?].
+- Vermelho num eixo não é compensado por verde noutro.
+
 ## Decisão de ampliar
 
 - O recorte demonstra o padrão de experiência/acabamento pretendido? [evidência e autor do julgamento].
+- Feel/áudio sincronizados no impacto e pacing estável no trecho? [observação].
 - O processo para produzir outro trecho está compreendido? [custo observado e dificuldade].
 - Limites: [o que esse recorte ainda não prova sobre o jogo completo].
 - Próxima fatia: [resultado, requisitos, dependências e prova].

--- a/examples/era-uma-vez-preproduction.md
+++ b/examples/era-uma-vez-preproduction.md
@@ -12,7 +12,9 @@ e ajudar os irmãos a voltar. A experiência pretendida combina descoberta e
 confiança na própria observação.
 
 Pilares deste recorte: o verbo do conto vira controle; erro permite recuperação;
-consequência aparece no cenário.
+consequência aparece no cenário. Feel e áudio da marca (pedra que permanece,
+migalha que some) fazem parte do ciclo, mesmo neste documento único. Escala:
+conto / jam.
 
 ## GDD e MDA
 

--- a/recipes/architecture.md
+++ b/recipes/architecture.md
@@ -66,8 +66,9 @@ possível. Examine apenas os eixos pertinentes:
   quando existente. Quem possui o relógio e qual estado a apresentação pode alterar?
 - **Persistência/conteúdo:** identidade, versões, loading e saves atuais; o que acontece
   com progresso existente e se é possível recuperar o estado anterior após uma mudança.
-- **Apresentação/recursos:** input, câmera, UI, áudio, carregamento e descarte de GPU,
-  timers/listeners. Contrato lógico correto ainda pode produzir regressão perceptível.
+- **Apresentação/recursos:** input, câmera, UI, áudio, feel do verbo, carregamento
+  e descarte de GPU, timers/listeners. Contrato lógico correto ainda pode produzir
+  regressão perceptível; feel e mix têm receitas próprias.
 - **Rede/serviços, quando presentes:** autoridade, ações recusadas, desconexão e limites
   externos. Exemplares locais não comprovam comportamento multiplayer.
 

--- a/recipes/audio.md
+++ b/recipes/audio.md
@@ -47,7 +47,11 @@ Para o verbo ou a transição em pauta:
    duplicado indicam recurso sobrevivente.
 
 Feel e áudio se confirmam: [feel](feel.md) descreve o impacto; esta receita
-garante que ele se ouve e se cala na hora certa.
+garante que ele se ouve e se cala na hora certa. O one-shot de impacto
+dispara no **mesmo frame** do hit-pause e do flash. Som atrasado não “pesa”
+o golpe — denuncia a costura. Som é o juice de maior retorno por esforço;
+verbo mudo continua sendo o defeito mais barato de corrigir e o mais caro
+de deixar.
 
 ## 3. REUSE → ADAPT → CREATE
 

--- a/recipes/audio.md
+++ b/recipes/audio.md
@@ -1,0 +1,100 @@
+# Áudio da consequência
+
+Entrada: ação ou transição que precisa ser ouvida, silenciada ou misturada,
+e a referência sonora aprovada (ou a lacuna explícita).
+
+Áudio AAA não é quantidade de arquivos. É mix: o jogador ouve a causa, o
+efeito e o espaço, e o silêncio também informa. Um loop 8-bit no lugar de
+uma gravação licenciada não cumpre o piso deste estúdio. jsfxr, chiptune
+e Kenney arcade não são o padrão.
+
+`context --focus audio` seleciona esta receita. Som novo no laboratório:
+`sfx search` antes de qualquer download; `sfx copy` leva o arquivo e a
+proveniência. Sem `shared/sfx`, o catálogo vem vazio — isso não autoriza
+improvisar licença.
+
+## 1. Nomear a camada
+
+Antes de importar, diga qual papel o som cumpre. Camadas típicas; use só
+as que o jogo tem:
+
+- **Ação / Foley** — passos, impactos, recusas, UI que é verbo.
+- **Mundo** — ambiente, ocupação do espaço, clima, máquinas.
+- **Música** — tensão, exploração, vitória; não papel de parede.
+- **Stinger / one-shot** — marco (descoberta, morte, checkpoint).
+- **Silêncio** — ausência deliberada após impacto, em menu, na morte.
+
+Um arquivo sem papel e sem consumidor não é áudio do jogo; é lixo no disco.
+Token de áudio no Art Bible precisa apontar o consumidor real (bus, evento,
+cena), como qualquer outro token.
+
+## 2. Seguir a ação até o mix
+
+Para o verbo ou a transição em pauta:
+
+1. **Disparo** — o que no estado dispara o som? Input, colisão, UI, timer,
+   rede? Disparo duplicado (dois listeners, restart sem stop) é o defeito
+   mais comum.
+2. **Corpo** — ataque, sustain, release. One-shot sem cauda pode parecer
+   clique; loop sem fade parece falha.
+3. **Ducking** — música e ambiente cedem à ação importante? Stinger come
+   a voz do verbo? Prioridade explícita evita volume máximo em tudo.
+4. **Espaço** — 2D/3D, oclusão, distância. Só quando o jogo já tem (ou
+   precisa de) espacialização; não adicione HRTF para cumprir checklist.
+5. **Interrupção** — pause, aba, morte, restart, troca de cena, unfocus.
+   Áudio que sobrevive é regressão de [ciclo de vida](lifecycle.md).
+6. **Descarte** — montar → desmontar → montar. Voz fantasma ou bus
+   duplicado indicam recurso sobrevivente.
+
+Feel e áudio se confirmam: [feel](feel.md) descreve o impacto; esta receita
+garante que ele se ouve e se cala na hora certa.
+
+## 3. REUSE → ADAPT → CREATE
+
+Ordem:
+
+1. Consumidor e evento já existentes no jogo.
+2. `shared/sfx` no laboratório, se a pasta existir na raiz de `--root`.
+3. Acervo do próprio projeto (com crédito e licença já registrados).
+4. Download ou síntese **somente** com lacuna, licença compatível e
+   registro de origem. Geração externa distingue preview de asset
+   aprovado; não torna o fornecedor obrigatório.
+
+Adapte pitch, volume e envelope no canônico antes de duplicar o arquivo.
+Trocar um wav sem atualizar pivot rítmico, ducking ou interrupção é
+regressão. Conteúdo baixado não ganha licença nova pelo reuso.
+
+Piso: gravação licenciada ou design contemporâneo coerente com a Art
+Bible. Se o jogo **escolhe** chip/lo-fi, isso é direção explícita, não o
+padrão do estúdio — registre no design system.
+
+## 4. Música como design
+
+Música muda comportamento. Defina o que ela informa (perigo, progresso,
+calma) e o que a corta (stinger, diálogo, morte). Teste transição: entrar
+e sair de combate/menu/cutscene sem clique, sem camada dupla e sem
+silêncio acidental de vários segundos, salvo se o silêncio for a direção.
+
+Não use a faixa como prova de atmosfera se o verbo continua mudo. Em
+recorte sem música, declare a escolha; não invente trilha para o scanner
+ficar verde.
+
+## 5. Provar com e sem
+
+Compare nas mesmas condições, **com som e com mute**. O jogo ainda precisa
+ser legível no silêncio quando o recorte exigir acesso ou ambiente ruidoso.
+Verifique:
+
+- Ação central audível contra o ambiente.
+- Recusa audível e distinta do sucesso.
+- Pause/reset sem cauda.
+- Save/load ou troca de nível sem overlap.
+- Volume relativo: UI não grita sobre o mundo; impacto não estoura.
+
+Teste técnico de decode não aprova mix. Avaliação do agente não é
+aprovação do usuário. Sem referência sonora, a lacuna permanece explícita.
+
+Origem: piso de áudio do [README](../README.md),
+[qualidade](../references/quality.md),
+[ambição](../references/ambition.md) e catálogo `shared/sfx` do laboratório.
+Este repositório não inclui os arquivos de som.

--- a/recipes/content.md
+++ b/recipes/content.md
@@ -6,8 +6,9 @@ Leia o formato atual, sua carga em runtime e os consumidores. Procure definiçã
 slot substituível antes de duplicar lógica. Preserve identidade, escala, pivot,
 colisões, animações e referências ao trocar arte. Som novo: consulte
 `shared/sfx` no laboratório (`sfx search`) antes de baixar; copie o arquivo e a
-proveniência. Registre origem e condições de uso; conteúdo baixado não recebe
-uma licença nova pelo simples reuso.
+proveniência. Mix, interrupção e silêncio seguem [áudio](audio.md), não apenas
+a cópia do arquivo. Registre origem e condições de uso; conteúdo baixado não
+recebe uma licença nova pelo simples reuso.
 
 Geração externa (Magnific e similares) distingue capacidades documentadas de
 integração comprovada. Não torna o fornecedor obrigatório.

--- a/recipes/create.md
+++ b/recipes/create.md
@@ -5,28 +5,54 @@ Se algo foi omitido, assuma a opção coerente com o acervo e registre; só inte
 por decisão indispensável. O destino de um jogo novo deve ser novo; continuação usa
 o projeto atual.
 
+O caminho curto está em [ambição](../references/ambition.md): um ciclo jogável
+na primeira sessão, depois feel e áudio do verbo, depois receita de conteúdo.
+Não gere todos os templates antes de experimentar. Nove arquivos vazios não
+aumentam a qualidade; uma fatia sem feel continua sendo protótipo.
+
 Siga [o ciclo de pré-produção](../references/preproduction.md) para escolher o
 próximo artefato e revisar sua prontidão. Brief e GDD definem a experiência; MDA
 explicita a hipótese; PoC a investiga; PRD/TDD delimitam requisitos e implementação;
 vertical slice e MVP têm objetivos distintos; QA e playtest alimentam o design.
 Carregue o template da etapa com `context <projeto> --stage <etapa>` e adapte o
-documento canônico. Não gere todos os arquivos antes de começar a experimentar.
-Uma direção aprovada exige sincronizar a base oficial no mesmo turno, conforme
+documento canônico. Uma direção aprovada exige sincronizar a base oficial no mesmo
+turno, conforme
 [o roteiro](../references/project-audit.md#aprovação-de-direção-materializar-e-continuar).
 Cubra as nove áreas com conteúdo ou lacunas explícitas, em documentos proporcionais
 ao projeto, e prossiga com o recorte solicitado. O usuário não precisa pedir essa base.
 
-1. Consulte o [playground](https://games.alanicolas.com/) e identifique uma família
-   compatível. Procure código, contratos e conteúdo reutilizável no jogo escolhido.
-   Som: se o laboratório tiver `shared/sfx`, use `sfx search` antes de qualquer
-   download. Explique REUSE, ADAPT ou CREATE antes de produzir novos sistemas.
-2. Construa um ciclo jogável com uma decisão característica da proposta. Defina
-   entrada, objetivo percebido, consequência, término e repetição. Título e cores
-   novos não demonstram uma experiência nova.
-3. Faça a primeira fatia atravessar controles, estado, apresentação e conteúdo.
-   Valide essa integração antes de multiplicar fases, itens ou personagens.
-4. Compare com a intenção e com a referência visual. Preserve funcionalidades
-   explicitamente pedidas e registre o que foi herdado versus produzido.
+Declare a **escala** no brief: jam/conto, produto ou AAA-shaped. A escala governa
+quantidade de artefatos e de conteúdo. O piso do verbo — decisão, feel, áudio da
+consequência — não é opcional em nenhuma delas.
+
+## Primeira sessão
+
+1. Consulte o [playground](https://games.alanicolas.com/) e o acervo local.
+   Identifique uma família compatível. Procure código, contratos e conteúdo
+   reutilizável. Som: se o laboratório tiver `shared/sfx`, use `sfx search`
+   antes de qualquer download. Explique REUSE, ADAPT ou CREATE antes de
+   produzir novos sistemas.
+2. Construa um ciclo jogável com uma decisão característica. Defina entrada,
+   objetivo percebido, consequência, término e repetição. Título e cores novos
+   não demonstram uma experiência nova.
+3. Faça essa fatia atravessar controles, estado, apresentação e conteúdo.
+   Valide a integração antes de multiplicar fases, itens ou personagens.
+4. Aplique o feel e o áudio **desse** verbo. Use `--focus feel` e
+   `--focus audio`. Arte provisória é aceitável se a direção estiver
+   declarada; verbo mudo ou sem peso não é.
+5. Compare com a intenção e com a referência, em movimento. Preserve o que
+   foi pedido. Registre herdado versus produzido e **uma** próxima ação.
+
+## Da fatia à produção
+
+A escada: fantasia → ciclo → feel → áudio → receita de conteúdo → vertical
+slice no piso → produção sem diluir. PoC reduz incerteza; scaffold mostra
+estrutura; slice mostra experiência no acabamento pretendido.
+
+Em escala AAA-shaped, feel, mix, luz, animação e a receita do próximo item
+são requisitos do recorte, não “polimento depois”. Reduza quantidade de
+conteúdo; não reduza o piso aprovado. Se a slice não demonstra que outro
+trecho nasce no mesmo padrão, ainda não está pronta para ampliar.
 
 Pontos de partida a **examinar**, não bases aprovadas automaticamente:
 
@@ -37,8 +63,13 @@ Pontos de partida a **examinar**, não bases aprovadas automaticamente:
 - Unity: protótipo local com verificações próprias; presença em `prototypes/` não
   declara publicação.
 
+Não copie paleta, feel ou mix de uma família sem ADAPT e proveniência. O
+destino continua com instância própria no design system.
+
 BMad inspira leitura por etapa e retomada (`RE-GDS-002`, `RE-GDS-022`); seus passos
 textuais não são uma garantia de execução. [Fonte](../references/sources.md).
 
-Concluir exige conteúdo distintivo, cenário real e QA. Scaffold ou cópia que inicia
-continua sendo ponto de partida. Esta receita não copia nem publica projetos por si.
+Concluir o pedido exige conteúdo distintivo, cenário real e QA. Scaffold ou
+cópia que inicia continua sendo ponto de partida. Esta receita não copia nem
+publica projetos por si. Não chame o recorte de AAA se as barras da escala
+não foram demonstradas na slice.

--- a/recipes/create.md
+++ b/recipes/create.md
@@ -43,6 +43,8 @@ opcional em nenhuma delas. Não use “AAA” como adjetivo do build.
    declarada; verbo mudo ou sem peso não é.
 5. Compare com a intenção e com a referência, em movimento. Preserve o que
    foi pedido. Registre herdado versus produzido e **uma** próxima ação.
+   Não gere o template `aaa` nesta sessão. O `finish.action` permanece
+   `defer_until_playable_cycle` até existir o ciclo.
 
 ## Da fatia à produção
 

--- a/recipes/create.md
+++ b/recipes/create.md
@@ -21,9 +21,10 @@ turno, conforme
 Cubra as nove áreas com conteúdo ou lacunas explícitas, em documentos proporcionais
 ao projeto, e prossiga com o recorte solicitado. O usuário não precisa pedir essa base.
 
-Declare a **escala** no brief: jam/conto, produto ou AAA-shaped. A escala governa
-quantidade de artefatos e de conteúdo. O piso do verbo — decisão, feel, áudio da
-consequência — não é opcional em nenhuma delas.
+Declare a **escala** no brief: jam/conto, produto ou AA / Triple-I (piso de
+acabamento). A escala governa quantidade de artefatos e de conteúdo. O piso
+do verbo — decisão, feel sincronizado, áudio da consequência, pacing — não é
+opcional em nenhuma delas. Não use “AAA” como adjetivo do build.
 
 ## Primeira sessão
 
@@ -49,10 +50,12 @@ A escada: fantasia → ciclo → feel → áudio → receita de conteúdo → ve
 slice no piso → produção sem diluir. PoC reduz incerteza; scaffold mostra
 estrutura; slice mostra experiência no acabamento pretendido.
 
-Em escala AAA-shaped, feel, mix, luz, animação e a receita do próximo item
-são requisitos do recorte, não “polimento depois”. Reduza quantidade de
-conteúdo; não reduza o piso aprovado. Se a slice não demonstra que outro
-trecho nasce no mesmo padrão, ainda não está pronta para ampliar.
+Em escala AA / Triple-I, feel, mix, luz, animação, pacing e a receita do
+próximo item são requisitos do recorte, não “polimento depois”. Reduza
+quantidade de conteúdo; não reduza o piso aprovado. Se a slice não demonstra
+repeatability — outro trecho nasce no mesmo padrão, sem heroísmo — ainda
+não está pronta para ampliar. Isso é piso de acabamento, não tier de
+publisher.
 
 Pontos de partida a **examinar**, não bases aprovadas automaticamente:
 
@@ -72,4 +75,5 @@ textuais não são uma garantia de execução. [Fonte](../references/sources.md)
 Concluir o pedido exige conteúdo distintivo, cenário real e QA. Scaffold ou
 cópia que inicia continua sendo ponto de partida. Esta receita não copia nem
 publica projetos por si. Não chame o recorte de AAA se as barras da escala
-não foram demonstradas na slice.
+— feel sincronizado, mix, pacing, repeatability — não foram demonstradas na
+slice.

--- a/recipes/feel.md
+++ b/recipes/feel.md
@@ -3,9 +3,11 @@
 Entrada: verbo central, referência de sensação (aprovada ou proposta) e a
 diferença percebida entre intenção e resposta atual.
 
-Feel é o intervalo entre o input e a certeza de que o mundo respondeu. AAA
-e jam se separam aqui com mais frequência do que na escolha da engine. Sem
-feel, o ciclo pode estar correto e o jogo parecer vazio.
+Feel é o intervalo entre o input e a certeza de que o mundo respondeu.
+Swink: controle em tempo real, espaço simulado, polish. Jam e piso de
+acabamento se separam aqui com mais frequência do que na escolha da engine.
+Sem feel, o ciclo pode estar correto e o jogo parecer vazio. Sem sincronia,
+o juice vira ruído.
 
 Leia o verbo no GDD, os tokens de tempo/câmera/áudio no
 [design system](../references/game-design-system.md) e o
@@ -44,7 +46,9 @@ Siga a ação da intenção ao descanso. Examine só os elos que o recorte tem
    ou cursor. A silhueta muda o bastante para ser lida em movimento.
 5. **Impacto** — hitstop, freeze frames, flash, partículas, rumble, stinger.
    Duração proporcional à importância; impacto de coleta não pode parecer
-   golpe mortal, e o contrário também.
+   golpe mortal, e o contrário também. Visual, áudio e pause de hit disparam
+   no **mesmo frame** do contato. Alguns milissegundos de atraso fazem o
+   cérebro registrar dois eventos, não um peso.
 6. **Câmera** — punch, lookahead, aterrissagem, oclusão, recuperação. A
    câmera confirma a ação sem enjoar nem esconder o próximo risco.
 7. **Áudio** — ataque, corpo, impacto, cauda e silêncio. Sem camada que
@@ -88,7 +92,9 @@ Evite:
 
 A qualidade aprovada é o piso. Não corte feel para ganhar FPS; investigue
 implementação mais barata que preserve a percepção (menos overdraw, mesmo
-punch).
+punch). Antes de negociar fidelidade gráfica, observe latência de input e
+spikes de frametime no mesmo trecho: stutter quebra o feel com mais força
+do que um preset mais baixo.
 
 ## 5. Provar em movimento
 
@@ -102,6 +108,7 @@ esperada, condição equivalente e julgamento (agente ou pessoa, sem
 confundir). Sem referência aprovada, registre que o piso ainda é proposta.
 
 Fontes de método: [qualidade](../references/quality.md),
-[ambição](../references/ambition.md), Art Bible do jogo. Estudos de
-câmera/tempo no laboratório, quando existirem, são precedentes — não um
+[ambição](../references/ambition.md), Art Bible do jogo, Swink / *Juice it
+or lose it* no [mapa](../references/sources.md#aaa-tier-e-piso-09). Estudos
+de câmera/tempo no laboratório, quando existirem, são precedentes — não um
 kit de juice obrigatório.

--- a/recipes/feel.md
+++ b/recipes/feel.md
@@ -1,0 +1,107 @@
+# Feel da ação
+
+Entrada: verbo central, referência de sensação (aprovada ou proposta) e a
+diferença percebida entre intenção e resposta atual.
+
+Feel é o intervalo entre o input e a certeza de que o mundo respondeu. AAA
+e jam se separam aqui com mais frequência do que na escolha da engine. Sem
+feel, o ciclo pode estar correto e o jogo parecer vazio.
+
+Leia o verbo no GDD, os tokens de tempo/câmera/áudio no
+[design system](../references/game-design-system.md) e o
+[piso](../references/quality.md). `context --focus feel` seleciona esta
+receita. O usuário não precisa pedir “ative o juice”.
+
+## 1. Isolar o verbo
+
+Descreva **uma** ação: o que o jogador faz, o que o estado muda, o que os
+olhos e os ouvidos deveriam confirmar. Se várias ações competem, comece
+pela que o brief chama de central.
+
+Separe:
+
+- **Regra** — a ação é legal, o estado muda, a recusa existe.
+- **Apresentação** — a mudança é perceptível.
+- **Feel** — a percepção tem peso, timing e recuperação.
+
+Corrigir a regra não substitui o feel. Animar demais não substitui a regra.
+Se a ação ainda não existe, volte a [criar](create.md) ou a
+[mecânicas](mechanics.md); esta receita assume um ciclo jogável.
+
+## 2. Cadeia perceptível
+
+Siga a ação da intenção ao descanso. Examine só os elos que o recorte tem
+(ou deveria ter). Nomes abaixo são vocabulário de inspeção, não uma API.
+
+1. **Intenção** — o jogador sabe que pode agir? Ameaça e oportunidade são
+   legíveis antes do input.
+2. **Input** — latência, deadzone, buffer, cancelamento, perda de foco,
+   toque versus gamepad versus mouse. O mesmo verbo pode falhar numa entrada
+   e funcionar em outra.
+3. **Antecipação** — frames ou pose que prometem o golpe/pulo/disparo antes
+   do impacto. Sem ela, a ação chega “de graça” ou atrasada demais.
+4. **Resposta de corpo** — squash, stretch, deslocamento, IK, arma, veículo
+   ou cursor. A silhueta muda o bastante para ser lida em movimento.
+5. **Impacto** — hitstop, freeze frames, flash, partículas, rumble, stinger.
+   Duração proporcional à importância; impacto de coleta não pode parecer
+   golpe mortal, e o contrário também.
+6. **Câmera** — punch, lookahead, aterrissagem, oclusão, recuperação. A
+   câmera confirma a ação sem enjoar nem esconder o próximo risco.
+7. **Áudio** — ataque, corpo, impacto, cauda e silêncio. Sem camada que
+   marque o verbo, o feel fica visual-only; use [áudio](audio.md).
+8. **Recuperação** — o jogador volta ao controle num tempo justo. Recovery
+   invisível ou infinito quebra confiança.
+
+Registre o elo fraco antes de adicionar mais partículas. Três efeitos no
+impacto não compensam input que ignora o botão.
+
+## 3. REUSE → ADAPT → CREATE
+
+Procure o feel já existente no jogo: hitstop, easing, impulse de câmera,
+envelope de som, rumble. Leia o **consumidor** (o golpe, o pulo, o clique),
+não só o utilitário. Um tween genérico sem dono não é feel reutilizável.
+
+- **REUSE:** o envelope atual atende com outros parâmetros.
+- **ADAPT:** estenda o canônico (mesmo hitstop, outra curva) e preserve quem
+  já o consome.
+- **CREATE:** nenhuma cadeia existente cobre o verbo sem acoplamento
+  estranho. Explicite a lacuna; crie só o elo que falta.
+
+Não importe um “juice pack” universal. Feel copiado de outro jogo sem ADAPT
+e proveniência dilui a instância. 8-bit, bounce cartoon ou screen-shake
+contínuo não são o padrão; o padrão é a referência aprovada deste jogo.
+
+## 4. Ajustar uma variável por vez
+
+Feel é causal. Altere duração, escala ou intensidade de **um** elo e
+compare nas mesmas condições: versão, resolução, entrada, trecho, seed
+quando demonstrada. Valores iniciais do acervo são ponto de partida, não
+constantes universais.
+
+Evite:
+
+- Juice que atrasa o próximo input além do que o ritmo pede.
+- Câmera que combate o jogador ou esconde a ameaça.
+- Hitstop em toda interação até o tempo parecer quebrado.
+- Partículas que tapam a silhueta da consequência.
+- Compensar regra injusta com feedback “gostoso”.
+
+A qualidade aprovada é o piso. Não corte feel para ganhar FPS; investigue
+implementação mais barata que preserve a percepção (menos overdraw, mesmo
+punch).
+
+## 5. Provar em movimento
+
+Screenshot não comprova feel. Compare o antes/depois no percurso real.
+Observe também pause, perda de foco, reinício e troca de entrada: um
+hitstop que sobrevive à pausa ou um rumble que não morre no descarte é
+regressão de [ciclo de vida](lifecycle.md).
+
+No QA, um caso de feel declara: ação, elo sob teste, duração/escala
+esperada, condição equivalente e julgamento (agente ou pessoa, sem
+confundir). Sem referência aprovada, registre que o piso ainda é proposta.
+
+Fontes de método: [qualidade](../references/quality.md),
+[ambição](../references/ambition.md), Art Bible do jogo. Estudos de
+câmera/tempo no laboratório, quando existirem, são precedentes — não um
+kit de juice obrigatório.

--- a/recipes/mechanics.md
+++ b/recipes/mechanics.md
@@ -13,7 +13,9 @@ estado em todas as bibliotecas; confirme a implementação local.
 
 Teste invariantes nos limites: recursos não duplicam, ações recusadas não consomem
 turno indevidamente, vitória/derrota não dispara duas vezes. Separe esse teste da
-pergunta criativa: a decisão é compreensível e vale a pena?
+pergunta criativa: a decisão é compreensível e vale a pena? A regra correta com
+verbo sem peso ainda pede [feel](feel.md); recusa e sucesso precisam ser
+distintos também no [áudio](audio.md).
 
 Para ajuste de dificuldade ou economia, registre situação inicial, comportamento
 observado e variável alterada. Compare alternativas sob o mesmo cenário. Não deduza

--- a/recipes/visual.md
+++ b/recipes/visual.md
@@ -23,7 +23,9 @@ animação como solução automática de FPS.
 
 Na câmera, observe antecipação de curvas/ameaças, oclusão do jogador, estabilidade,
 escala e transição. No mundo, compare silhueta, materiais, luz, sombras, efeitos e
-coerência em movimento, não apenas a melhor screenshot.
+coerência em movimento, não apenas a melhor screenshot. Feel da ação e mix da
+consequência têm receitas próprias: [feel](feel.md), [áudio](audio.md). Não trate
+partículas ou um loop de fundo como substituto desses focos.
 
 Casos já documentados: nomes podem mudar após o carregamento do GLTF; culling deve
 ser testado em todas as aberturas visíveis; animação em shader invalida suposições

--- a/references/aaa-checklist.md
+++ b/references/aaa-checklist.md
@@ -1,0 +1,59 @@
+# Checklist de piso de acabamento
+
+Instrumento de observação, não certificado. Completar linhas não torna o
+jogo AAA de publisher e não mede diversão. “AAA” neste texto é o
+[piso de acabamento](ambition.md) da fatia — verbo, feel sincronizado, mix,
+pacing, mundo, confiança e repeatability.
+
+Use no recorte que existe: uma vertical slice, um capítulo, um verbo. Não
+marque o jogo inteiro por uma still. Itens que o recorte **não promete**
+ficam `N/A` com motivo; inventar rede, live ops ou localização para
+“completar o AAA” é desonesto.
+
+O template preenchível é [aaa](../assets/templates/aaa.md).
+`context --stage aaa` e `template aaa --project <jogo>` carregam esta guia
+e o rascunho. Reaproveite o QA e a slice canônicos; não crie um terceiro
+arquivo se um já cobre as linhas.
+
+## Estados
+
+Para cada item aplicável:
+
+| Estado | Significa |
+| --- | --- |
+| `não executado` | Ainda não observado neste recorte. |
+| `observado` | Há evidência em movimento (ou comando, quando o item for técnico) e um autor. |
+| `inconclusivo` | Observou-se, mas a evidência não distingue a hipótese. |
+| `N/A` | O recorte declara que o item não se aplica; o motivo é obrigatório. |
+
+Screenshot isolada não promove `não executado` a `observado` em feel,
+animação, câmera, mix ou pacing. Avaliação do agente não é aprovação do
+usuário. Não some itens para uma “nota AAA”. Um vermelho material bloqueia
+o adjetivo; verdes noutros eixos não compensam.
+
+## O que o checklist não pede
+
+Orçamento de US$ 100 mi, equipe de 200 pessoas, marketing de blockbuster,
+live ops, microtransação, ray tracing, celebridade na voz e o rótulo AAAA
+**não** são itens do piso. Se o projeto for de fato desse tier, registre-os
+na seção de mercado como contexto — nunca como condição para o acabamento.
+
+## Quando preencher
+
+- Na vertical slice, antes de decidir ampliar.
+- Quando o usuário pedir “está AAA?”, “o que falta?” ou equivaler.
+- Em QA de recorte que promete o piso (escala AA / Triple-I ou produto
+  com acabamento explícito).
+- Jam/conto pode usar só as seções do verbo, feel, áudio, pacing e
+  confiança; o resto fica `N/A` com a escala.
+
+## Continuidade
+
+- **Onde estamos:** as barras existiam em ambição e qualidade; faltava um
+  instrumento único, preenchível, com N/A e prova.
+- **Próximo passo:** ao fechar uma slice ou ao ser perguntado pelo piso,
+  preencher ou atualizar o canônico — uma linha por item afetado.
+- **Por que agora:** sem o checklist, o agente usa “AAA” de ouvido.
+- **Pronto quando:** todo item aplicável tem estado, evidência ou lacuna
+  com próxima ação; o resumo nomeia o que ainda impede o adjetivo.
+- **Retomar por:** este guia, o template, a slice e o QA do jogo.

--- a/references/aaa-checklist.md
+++ b/references/aaa-checklist.md
@@ -1,59 +1,101 @@
 # Checklist de piso de acabamento
 
-Instrumento de observação, não certificado. Completar linhas não torna o
-jogo AAA de publisher e não mede diversão. “AAA” neste texto é o
-[piso de acabamento](ambition.md) da fatia — verbo, feel sincronizado, mix,
-pacing, mundo, confiança e repeatability.
+Instrumento de observação da **fatia**, não certificado e não nota. Completar
+linhas não torna o jogo AAA de publisher e não mede diversão. “AAA” aqui é o
+[piso](ambition.md): verbo, feel sincronizado, mix, pacing, mundo, confiança
+e repeatability.
 
-Use no recorte que existe: uma vertical slice, um capítulo, um verbo. Não
-marque o jogo inteiro por uma still. Itens que o recorte **não promete**
-ficam `N/A` com motivo; inventar rede, live ops ou localização para
-“completar o AAA” é desonesto.
+O harness não preenche o checklist. Ele recorta **quais grupos valem**
+(`finish` no `context`) e aponta esta guia. O agente observa o recorte
+real e escreve no canônico do jogo — um documento combinado basta.
 
-O template preenchível é [aaa](../assets/templates/aaa.md).
-`context --stage aaa` e `template aaa --project <jogo>` carregam esta guia
-e o rascunho. Reaproveite o QA e a slice canônicos; não crie um terceiro
-arquivo se um já cobre as linhas.
+Template: [aaa](../assets/templates/aaa.md).
+`context --stage aaa` imprime o rascunho inteiro. Slice, QA, `feel` e
+`audio` já carregam **esta guia**; não geram arquivo novo.
+
+## Como se adapta ao framework
+
+O checklist não é um ciclo paralelo. Ele **observa** o que as outras
+peças já decidem ou implementam.
+
+| Peça do harness | O que o checklist faz |
+| --- | --- |
+| Brief / escala | Escolhe o perfil: jam = só **núcleo**; produto/AA soma **produto**; o que não foi prometido fica em **promessa** ou `N/A` |
+| GDD / MDA | CHK-1 (verbo, escolha, recusa). Origem típica: GDD-M01 |
+| `--focus feel` / `--focus audio` | CHK-4 e CHK-5; a guia entra no `read_next` |
+| `--focus lifecycle` | CHK-11 (pause, reset, descarte) |
+| `--focus visual` / Art Bible | CHK-7 e CHK-8; hero comparison no engine |
+| `--focus content` | CHK-10 (receita, pipeline, custo) |
+| `--focus network` | CHK-12 só se houver estado compartilhado |
+| `--focus architecture` / TDD | Contratos que CHK-6 e CHK-11 precisam provar |
+| `--stage vertical-slice` | Fecha o núcleo (+ produto, se a escala pedir) **antes** de ampliar |
+| `--stage qa` | Evidência: CHK-14 liga IDs a casos e playtest |
+| `verify` | Recibo técnico; `experience_status` continua `not_assessed` até movimento |
+| Scan / nove áreas | Um arquivo de checklist é candidato de **QA**, não uma décima área |
+
+Não invente rede, live ops, mocap ou locale para “completar o AAA”.
+Isso já é regra da [auditoria](project-audit.md).
+
+## Três perfis (não três notas)
+
+O objeto `finish` do `context` lista os grupos. O agente não decora a tabela.
+
+| Perfil | Grupos | Quando |
+| --- | --- | --- |
+| **Núcleo** | CHK-0, CHK-1, CHK-2, CHK-4, CHK-5, CHK-6, CHK-11 | Qualquer escala, assim que existir um ciclo jogável |
+| **Produto** | CHK-3, CHK-7, CHK-8, CHK-10, CHK-14, CHK-15 | Escala produto ou AA / Triple-I; ou jam que prometeu câmera/mundo/HUD |
+| **Promessa** | CHK-9, CHK-12, CHK-13 | Só se o recorte prometeu narrativa/voz, rede ou outro idioma |
+| **Mercado** | CHK-16 | Contexto. **Nunca** reprova jam nem AA. Começa `N/A` |
+
+Jam: observe o núcleo; marque produto/promessa/mercado como `N/A` com a
+escala. Primeira sessão: **não** abra o template — construa o ciclo.
+Produto/AA: núcleo + produto, e as promessas declaradas no brief, **na
+slice**, antes de multiplicar conteúdo.
+
+`finish.action` no JSON:
+
+- `defer_until_playable_cycle` — ainda não há o que observar.
+- `observe_core_on_slice` — feche o núcleo (e o perfil da escala) neste recorte.
 
 ## Estados
-
-Para cada item aplicável:
 
 | Estado | Significa |
 | --- | --- |
 | `não executado` | Ainda não observado neste recorte. |
-| `observado` | Há evidência em movimento (ou comando, quando o item for técnico) e um autor. |
-| `inconclusivo` | Observou-se, mas a evidência não distingue a hipótese. |
-| `N/A` | O recorte declara que o item não se aplica; o motivo é obrigatório. |
+| `observado` | Evidência em movimento (ou comando, se o item for técnico) e um autor. |
+| `inconclusivo` | Observou-se; a evidência não distingue a hipótese. |
+| `N/A` | O recorte ou a escala declara que não se aplica; o motivo é obrigatório. |
 
-Screenshot isolada não promove `não executado` a `observado` em feel,
-animação, câmera, mix ou pacing. Avaliação do agente não é aprovação do
-usuário. Não some itens para uma “nota AAA”. Um vermelho material bloqueia
-o adjetivo; verdes noutros eixos não compensam.
+Screenshot isolada não fecha feel, animação, câmera, mix nem pacing.
+Avaliação do agente ≠ aprovação do usuário. Não some linhas. Um vermelho
+**material do perfil em vigor** bloqueia o adjetivo; verde noutro eixo
+não compensa.
+
+## Falhas típicas do agente
+
+- Gerar `template aaa` na primeira sessão e chamar o rascunho de progresso.
+- Preencher 70 linhas de um jam em vez do núcleo.
+- Marcar `observado` com still, typecheck ou opinião.
+- Inventar CHK-12/13/16 para o scanner ficar verde.
+- Usar “quase AAA” com núcleo em `não executado`.
+- Tratar CHK-16 (orçamento, live ops, BVT) como piso de acabamento.
+- Criar `aaa.md` paralelo quando a slice ou o QA já têm as linhas.
 
 ## O que o checklist não pede
 
-Orçamento de US$ 100 mi, equipe de 200 pessoas, marketing de blockbuster,
-live ops, microtransação, ray tracing, celebridade na voz e o rótulo AAAA
-**não** são itens do piso. Se o projeto for de fato desse tier, registre-os
-na seção de mercado como contexto — nunca como condição para o acabamento.
-
-## Quando preencher
-
-- Na vertical slice, antes de decidir ampliar.
-- Quando o usuário pedir “está AAA?”, “o que falta?” ou equivaler.
-- Em QA de recorte que promete o piso (escala AA / Triple-I ou produto
-  com acabamento explícito).
-- Jam/conto pode usar só as seções do verbo, feel, áudio, pacing e
-  confiança; o resto fica `N/A` com a escala.
+Orçamento de US$ 100 mi, equipe de 200, marketing de blockbuster, live ops,
+microtransação, ray tracing, celebridade na voz e AAAA **não** são piso.
+Se o projeto for desse tier, CHK-16 registra o fato — nunca a condição
+para o acabamento.
 
 ## Continuidade
 
-- **Onde estamos:** as barras existiam em ambição e qualidade; faltava um
-  instrumento único, preenchível, com N/A e prova.
-- **Próximo passo:** ao fechar uma slice ou ao ser perguntado pelo piso,
-  preencher ou atualizar o canônico — uma linha por item afetado.
-- **Por que agora:** sem o checklist, o agente usa “AAA” de ouvido.
-- **Pronto quando:** todo item aplicável tem estado, evidência ou lacuna
-  com próxima ação; o resumo nomeia o que ainda impede o adjetivo.
-- **Retomar por:** este guia, o template, a slice e o QA do jogo.
+- **Onde estamos:** o template existia como etapa solta; o agente só o via
+  com `--stage aaa`.
+- **Próximo passo:** na slice ou em “está AAA?”, observar o perfil que o
+  `finish` indicar e gravar no canônico.
+- **Por que agora:** sem perfil e sem carga na slice/QA, o checklist não
+  pertence ao framework — é um anexo.
+- **Pronto quando:** o núcleo do recorte tem estado ou `N/A`; o resumo
+  nomeia o que ainda impede o adjetivo; a próxima ação é uma.
+- **Retomar por:** `finish` no `context`, este guia, a slice e o QA do jogo.

--- a/references/ambition.md
+++ b/references/ambition.md
@@ -1,15 +1,35 @@
-# Ambição, facilidade e piso AAA
+# Ambição, facilidade e piso de acabamento
 
 Este framework não é um motor AAA e não fabrica um jogo grande sozinho. Ele é o
 contrato que torna a criação com IA **fácil de começar** e **difícil de
 rebaixar**: um pedido vira um ciclo jogável; um recorte ambicioso não chama
 scaffold de vertical slice.
 
-AAA, aqui, não é orçamento, equipe nem engine. É o **acabamento pretendido**
-demonstrado num trecho pequeno: verbo legível, feel da ação, mix audível,
-luz/materiais/animação coerentes, conteúdo que se multiplica sem diluir a
-direção aprovada. Um conto Canvas pode cumprir esse piso; um open world que
-abre sem feel não cumpre.
+Há **dois sentidos** de AAA. Misturá-los é o modo mais comum de um agente
+usar o adjetivo no vazio.
+
+1. **Tier de mercado.** Rótulo financeiro, sem órgão certificador. Nasceu no
+   varejo dos anos 1990, copiado da nota AAA de crédito: publisher médio/grande,
+   orçamento e marketing acima do resto. Em 2023–26 o piso citado gira em
+   centenas de milhões, equipes de centenas, ciclos de vários anos. Esse tier
+   é perfil de risco. Não promete diversão, originalidade nem ausência de bug.
+2. **Piso de acabamento.** O que o jogador chama de “qualidade AAA”: cada
+   sistema tratado como cidadão de primeira classe; primeiro minuto competente
+   (input, frame, câmera); feel e áudio no mesmo frame do impacto; mundo
+   legível em movimento; consistência de família; transições sem costura;
+   confiança (save, UI, erro). Um conto Canvas pode cumprir esse piso. Um
+   open world de orçamento AAA que abre sem peso na ação não cumpre.
+
+Neste repositório, “AAA” **só** significa o segundo sentido, e só depois da
+vertical slice demonstrar as barras da escala escolhida. Não chame o recorte
+de AAA, “quase AAA” ou AAAA por trailer, engine, ray tracing ou quantidade
+de conteúdo. AAAA não tem definição acordada; é buzzword.
+
+O alvo honesto para criação com IA é **AA / Triple-I com piso de acabamento**:
+escopo focado, receita repetível, mesmo critério de fatia. *Hellblade*,
+*A Plague Tale* e *Clair Obscur: Expedition 33* são precedentes de mercado
+desse território — não *GTA* nem live service de publisher. Fontes e limites:
+[mapa](sources.md#aaa-tier-e-piso-09).
 
 ## O que nos propomos a fazer
 
@@ -20,15 +40,15 @@ abre sem feel não cumpre.
   agente não vira decisão; screenshot isolada não vira aprovação.
 - **Reusar antes de inventar.** CREATE só entra com lacuna explícita.
 - **Provar o que afirma.** Build verde não comprova diversão, arte, reinício,
-  rede, direitos nem feel. Experiência sem observação em movimento permanece
-  `not_assessed`.
+  rede, direitos, feel nem pacing. Experiência sem observação em movimento
+  permanece `not_assessed`.
 - **Escalar a profundidade ao risco.** Jogo pequeno reúne decisões num
   documento. Projeto com sistemas distintos separa artefatos. A qualidade do
   verbo não é opcional em nenhum dos dois.
 
 O harness recorta contexto, varre a base e corre comandos com recibo. A IA
 lê, decide e implementa. A memória fica no jogo. Nenhum dos três mede
-diversão nem publica sozinho.
+diversão, publica sozinho ou promove o jogo ao tier de mercado AAA.
 
 ## Fácil sem ser raso
 
@@ -40,9 +60,11 @@ de critério. Na primeira sessão de um jogo novo:
 2. Escreva ou adapte um brief curto (ou a seção equivalente). Não gere a
    pasta inteira de templates.
 3. Construa um ciclo: perceber → decidir → agir → consequência → reinício.
-4. Faça essa ação **parecer e soar** a intenção — feel e áudio do verbo,
-   mesmo com arte provisória, desde que a direção esteja declarada.
-5. Compare em movimento com a referência. Registre o próximo passo único.
+4. Faça essa ação **parecer e soar** a intenção — feel e áudio do verbo no
+   mesmo instante do impacto, mesmo com arte provisória, desde que a direção
+   esteja declarada.
+5. Compare em movimento com a referência. Sinta também latência e estabilidade
+   de frame nesse trecho. Registre o próximo passo único.
 
 Nove documentos vazios atrasam o jogo e não aumentam a qualidade. Uma fatia
 jogável sem feel também não: é protótipo, e deve ser nomeada como tal.
@@ -60,10 +82,16 @@ artefatos e tamanho do recorte — **não** o piso do verbo.
 | --- | --- | --- | --- |
 | **Jam / conto** | Uma sessão, um verbo, pouco conteúdo | Um `game-design.md` pode bastar | Ciclo jogável com feel do verbo e comparação em movimento |
 | **Produto** | Entregar valor a jogadores reais | Brief + GDD/MDA, PRD/TDD do recorte, slice, MVP, QA | Vertical slice no acabamento pretendido; MVP com hipótese de valor observável |
-| **AAA-shaped** | O recorte precisa sustentar produção longa sem diluir | Os mesmos, com feel, áudio, luz, animação e receita de conteúdo como requisitos do recorte — não “polimento depois” | A slice prova que **outro** trecho nasce no mesmo padrão, com custo e receita compreendidos |
+| **AA / Triple-I (piso de acabamento)** | Fantasia focada que precisa nascer de novo sem diluir | Os mesmos, com feel, áudio, luz, animação, pacing e receita de conteúdo como requisitos do recorte — não “polimento depois” | A slice prova **repeatability**: outro trecho nasce no mesmo padrão, com custo e receita compreendidos |
 
-“AAA-shaped” é uma decisão de qualidade e de produção, não uma promessa de
-escala de mercado. Reduza quantidade de conteúdo; não reduza o piso aprovado.
+O nome interno antigo “AAA-shaped” significa esta terceira linha: piso de
+acabamento em escopo focado. **Não** significa orçamento de publisher, equipe
+de centenas, live ops nem marketing de blockbuster. Reduza quantidade de
+conteúdo; não reduza o piso aprovado.
+
+Quem se vende com promessa cinematográfica será julgado por animação, voz,
+face e direção de cena — mesmo que o verbo seja o ponto forte. O contrato
+com o jogador acompanha o que o recorte promete, não o adjetivo no brief.
 
 Se a escala mudar, atualize o brief e as fronteiras. Não retroaja aprovação
 visual de um mock para mecânicas que ninguém jogou.
@@ -75,72 +103,85 @@ registrado (ex.: PoC técnica antes do GDD).
 
 1. **Fantasia e verbo** — quem o jogador é, o que faz, o que sente.
 2. **Ciclo jogável** — uma decisão característica com término e repetição.
-3. **Feel do verbo** — a ação tem peso, resposta e recuperação. Receita:
-   [feel](../recipes/feel.md).
-4. **Áudio da consequência** — causa e efeito também se ouvem; silêncio é
+3. **Feel do verbo** — a ação tem peso, resposta e recuperação, sincronizados.
+   Receita: [feel](../recipes/feel.md).
+4. **Áudio da consequência** — causa e efeito no mesmo instante; silêncio é
    design. Receita: [áudio](../recipes/audio.md).
 5. **Receita de conteúdo** — o próximo inimigo, sala ou efeito nasce sem
    improvisar o piso. Contrato: [design system](game-design-system.md).
-6. **Vertical slice no piso** — gameplay, arte, áudio e tecnologia no
-   acabamento pretendido, em movimento.
+6. **Vertical slice no piso** — gameplay, arte, áudio, pacing e tecnologia no
+   acabamento pretendido, em movimento, **e** o pipeline que produz o próximo
+   trecho sem heroísmo.
 7. **Produção sem diluir** — multiplicar conteúdo pela receita; qualquer
    atalho que quebre o piso é regressão, não velocidade.
 
 PoC investiga incerteza. Scaffold demonstra estrutura. Slice demonstra
-experiência. Confundi-los é o modo mais comum de um agente declarar vitória
-cedo demais.
+experiência **e** repeatability. Confundi-los é o modo mais comum de um
+agente declarar vitória cedo demais. A slice trava o piso → tempo por asset
+→ esforço → o que é possível ampliar. Sem essa trava, o plano de produção
+é chute.
 
 ## Barras operacionais (não nota)
 
 Selecione as que o recorte afeta. Não some arte + correção + diversão.
+Nenhuma destas barras é “ser AAA de publisher”.
 
 - **Verbo:** a escolha muda estado, rota ou expectativa; o risco é legível
   antes da punição.
 - **Controle:** entrada, câmera e recuperação sustentam o verbo em cada
   dispositivo alvo.
 - **Feel:** antecipação, impacto, câmera, partículas, rumble e silêncio
-  tornam a ação inequívoca. Juice que esconde o verbo é regressão.
+  tornam a ação inequívoca. Flash, hit-pause, shake, partícula e áudio
+  disparam no **mesmo frame** do contato; dessincronia vira dois eventos,
+  não um impacto. Juice que esconde o verbo é regressão.
 - **Mix:** camadas (ação, ambiente, música, UI) com ducking e interrupção;
   pause/reinício não deixam voz fantasma.
+- **Pacing:** latência de input e estabilidade de frame no trecho real.
+  Spike de frametime quebra suavidade e desempenho percebido com mais força
+  do que baixar um preset de textura. Não corte o piso aprovado para “ganhar
+  FPS”; investigue implementação mais barata que preserve a percepção.
 - **Mundo:** silhueta, material, luz e animação legíveis em movimento;
-  landmark e ameaça distinguíveis sem a melhor screenshot.
+  landmark e ameaça distinguíveis sem a melhor screenshot; família coerente
+  com o asset-herói, **no engine**, não só no DCC.
 - **Primeiro minuto:** a primeira ação ensina o verbo sem mural de texto;
-  tutorial que bloqueia o jogo não é onboarding.
+  tutorial que bloqueia o jogo não é onboarding. O primeiro minuto também
+  denuncia float, atraso e stutter.
 - **Acesso:** contraste, forma além da cor, foco, toque, movimento reduzido
-  quando o recorte os exige.
+  quando o recorte os exige — e quando a promessa de público os exige.
 - **Confiança:** iniciar, pausar, perder, ganhar, reiniciar e sair têm
-  consequências definidas.
-- **Produção:** um item novo da família segue a receita; proveniência e
-  consumidor são rastreados.
+  consequências definidas. Save, UI e erro não traem o jogador.
+- **Produção / repeatability:** um item novo da família segue a receita sem
+  intervenção excepcional; proveniência e consumidor são rastreados; custo
+  observado do próximo trecho é conhecido.
 
 O [protocolo](quality.md) registra cenário, condições, referência, evidência
 técnica e observação em movimento. Sem essa comparação, declare a lacuna.
-Não rebatize uma versão degradada como novo piso. Não chame o recorte de
-AAA — nem de “quase AAA” — se a slice não demonstra as barras que a escala
-escolheu.
+Não rebatize uma versão degradada como novo piso.
 
 ## O que este repositório continua recusando
 
 Não há engine comum, API universal de ações, avaliação automática de
 diversão, publicação automática nem hierarquia de agentes. Troca de modelo
 com qualidade equivalente continua hipótese. Os estudos externos foram
-lidos em recortes; seus testes não foram executados aqui.
+lidos em recortes; seus testes não foram executados aqui. A literatura de
+tier AAA não foi reproduzida neste harness: orçamentos e headcounts citados
+são contexto, não meta.
 
 O playground da Alan Studios é acervo de famílias e precedentes, não prova
 de que este harness produziu aqueles jogos e não base aprovada para copiar
- paleta ou feel.
+paleta ou feel.
 
 ## Continuidade
 
-- **Onde estamos:** o harness 0.8 cobria processo, scan e arquitetura
-  proporcional. Faltavam o caminho curto da primeira sessão, o feel e o
-  áudio como focos, e um contrato explícito de ambição.
+- **Onde estamos:** 0.9 abriu caminho curto, feel, áudio e o contrato de
+  ambição. A pesquisa de 2026-09-09 separou tier de mercado e piso de
+  acabamento e tornou pacing, sincronia e repeatability explícitos.
 - **Próximo passo:** ao criar ou elevar um jogo, usar este guia com
   `--focus create` (início), `--focus feel` ou `--focus audio` (acabamento),
-  sem gerar documentos que o recorte não precisa.
-- **Por que agora:** sem isso, o agente documenta demais e polida de menos,
-  ou entrega protótipo como produto.
-- **Pronto quando:** a escala está no brief, o ciclo existe, e o próximo
-  passo da escada está nomeado com prova.
+  sem gerar documentos que o recorte não precisa e sem chamar o build de AAA.
+- **Por que agora:** sem a distinção, o agente documenta demais, polida de
+  menos, ou usa “AAA” como adjetivo de marketing.
+- **Pronto quando:** a escala está no brief (jam / produto / AA–Triple-I),
+  o ciclo existe, e o próximo passo da escada está nomeado com prova.
 - **Retomar por:** este guia, [criar](../recipes/create.md),
   [qualidade](quality.md) e a continuidade do próprio jogo.

--- a/references/ambition.md
+++ b/references/ambition.md
@@ -156,7 +156,8 @@ Nenhuma destas barras é “ser AAA de publisher”.
 
 O [protocolo](quality.md) registra cenário, condições, referência, evidência
 técnica e observação em movimento. O instrumento único é o
-[checklist de piso](aaa-checklist.md) (`--stage aaa` / `template aaa`).
+[checklist de piso](aaa-checklist.md). O `context` escolhe o perfil em
+`finish`; `--stage aaa` só materializa o rascunho inteiro.
 Sem essa comparação, declare a lacuna. Não rebatize uma versão degradada
 como novo piso. Completar o checklist não é nota AAA.
 

--- a/references/ambition.md
+++ b/references/ambition.md
@@ -1,0 +1,146 @@
+# Ambição, facilidade e piso AAA
+
+Este framework não é um motor AAA e não fabrica um jogo grande sozinho. Ele é o
+contrato que torna a criação com IA **fácil de começar** e **difícil de
+rebaixar**: um pedido vira um ciclo jogável; um recorte ambicioso não chama
+scaffold de vertical slice.
+
+AAA, aqui, não é orçamento, equipe nem engine. É o **acabamento pretendido**
+demonstrado num trecho pequeno: verbo legível, feel da ação, mix audível,
+luz/materiais/animação coerentes, conteúdo que se multiplica sem diluir a
+direção aprovada. Um conto Canvas pode cumprir esse piso; um open world que
+abre sem feel não cumpre.
+
+## O que nos propomos a fazer
+
+- **Interpretar um pedido** e chegar a uma fatia jogável sem exigir que a
+  pessoa conheça o harness, preencha nove templates ou escolha uma hierarquia
+  de agentes.
+- **Preservar a direção** do usuário e a referência aprovada. Hipótese do
+  agente não vira decisão; screenshot isolada não vira aprovação.
+- **Reusar antes de inventar.** CREATE só entra com lacuna explícita.
+- **Provar o que afirma.** Build verde não comprova diversão, arte, reinício,
+  rede, direitos nem feel. Experiência sem observação em movimento permanece
+  `not_assessed`.
+- **Escalar a profundidade ao risco.** Jogo pequeno reúne decisões num
+  documento. Projeto com sistemas distintos separa artefatos. A qualidade do
+  verbo não é opcional em nenhum dos dois.
+
+O harness recorta contexto, varre a base e corre comandos com recibo. A IA
+lê, decide e implementa. A memória fica no jogo. Nenhum dos três mede
+diversão nem publica sozinho.
+
+## Fácil sem ser raso
+
+Fácil é **um caminho curto até a primeira decisão jogável**, não a ausência
+de critério. Na primeira sessão de um jogo novo:
+
+1. Resolva fantasia, verbo, plataforma e a maior incerteza. Assuma o resto
+   com registro; pergunte só o que impede de jogar.
+2. Escreva ou adapte um brief curto (ou a seção equivalente). Não gere a
+   pasta inteira de templates.
+3. Construa um ciclo: perceber → decidir → agir → consequência → reinício.
+4. Faça essa ação **parecer e soar** a intenção — feel e áudio do verbo,
+   mesmo com arte provisória, desde que a direção esteja declarada.
+5. Compare em movimento com a referência. Registre o próximo passo único.
+
+Nove documentos vazios atrasam o jogo e não aumentam a qualidade. Uma fatia
+jogável sem feel também não: é protótipo, e deve ser nomeada como tal.
+
+Use `context <projeto> --focus create`. Em “continue”, `--event resume`.
+Quando a pessoa aprovar imagem, conceito ou recorte, `--event direction-approved`
+e sincronize a base no mesmo turno. O usuário não precisa saber esses nomes.
+
+## Escala de ambição
+
+Escolha a escala no brief e mantenha-a visível. Ela governa quantidade de
+artefatos e tamanho do recorte — **não** o piso do verbo.
+
+| Escala | Quando | Artefatos | Pronto quando |
+| --- | --- | --- | --- |
+| **Jam / conto** | Uma sessão, um verbo, pouco conteúdo | Um `game-design.md` pode bastar | Ciclo jogável com feel do verbo e comparação em movimento |
+| **Produto** | Entregar valor a jogadores reais | Brief + GDD/MDA, PRD/TDD do recorte, slice, MVP, QA | Vertical slice no acabamento pretendido; MVP com hipótese de valor observável |
+| **AAA-shaped** | O recorte precisa sustentar produção longa sem diluir | Os mesmos, com feel, áudio, luz, animação e receita de conteúdo como requisitos do recorte — não “polimento depois” | A slice prova que **outro** trecho nasce no mesmo padrão, com custo e receita compreendidos |
+
+“AAA-shaped” é uma decisão de qualidade e de produção, não uma promessa de
+escala de mercado. Reduza quantidade de conteúdo; não reduza o piso aprovado.
+
+Se a escala mudar, atualize o brief e as fronteiras. Não retroaja aprovação
+visual de um mock para mecânicas que ninguém jogou.
+
+## Escada até o acabamento
+
+Orientação de dependências, não esteira rígida. Pule um degrau só com motivo
+registrado (ex.: PoC técnica antes do GDD).
+
+1. **Fantasia e verbo** — quem o jogador é, o que faz, o que sente.
+2. **Ciclo jogável** — uma decisão característica com término e repetição.
+3. **Feel do verbo** — a ação tem peso, resposta e recuperação. Receita:
+   [feel](../recipes/feel.md).
+4. **Áudio da consequência** — causa e efeito também se ouvem; silêncio é
+   design. Receita: [áudio](../recipes/audio.md).
+5. **Receita de conteúdo** — o próximo inimigo, sala ou efeito nasce sem
+   improvisar o piso. Contrato: [design system](game-design-system.md).
+6. **Vertical slice no piso** — gameplay, arte, áudio e tecnologia no
+   acabamento pretendido, em movimento.
+7. **Produção sem diluir** — multiplicar conteúdo pela receita; qualquer
+   atalho que quebre o piso é regressão, não velocidade.
+
+PoC investiga incerteza. Scaffold demonstra estrutura. Slice demonstra
+experiência. Confundi-los é o modo mais comum de um agente declarar vitória
+cedo demais.
+
+## Barras operacionais (não nota)
+
+Selecione as que o recorte afeta. Não some arte + correção + diversão.
+
+- **Verbo:** a escolha muda estado, rota ou expectativa; o risco é legível
+  antes da punição.
+- **Controle:** entrada, câmera e recuperação sustentam o verbo em cada
+  dispositivo alvo.
+- **Feel:** antecipação, impacto, câmera, partículas, rumble e silêncio
+  tornam a ação inequívoca. Juice que esconde o verbo é regressão.
+- **Mix:** camadas (ação, ambiente, música, UI) com ducking e interrupção;
+  pause/reinício não deixam voz fantasma.
+- **Mundo:** silhueta, material, luz e animação legíveis em movimento;
+  landmark e ameaça distinguíveis sem a melhor screenshot.
+- **Primeiro minuto:** a primeira ação ensina o verbo sem mural de texto;
+  tutorial que bloqueia o jogo não é onboarding.
+- **Acesso:** contraste, forma além da cor, foco, toque, movimento reduzido
+  quando o recorte os exige.
+- **Confiança:** iniciar, pausar, perder, ganhar, reiniciar e sair têm
+  consequências definidas.
+- **Produção:** um item novo da família segue a receita; proveniência e
+  consumidor são rastreados.
+
+O [protocolo](quality.md) registra cenário, condições, referência, evidência
+técnica e observação em movimento. Sem essa comparação, declare a lacuna.
+Não rebatize uma versão degradada como novo piso. Não chame o recorte de
+AAA — nem de “quase AAA” — se a slice não demonstra as barras que a escala
+escolheu.
+
+## O que este repositório continua recusando
+
+Não há engine comum, API universal de ações, avaliação automática de
+diversão, publicação automática nem hierarquia de agentes. Troca de modelo
+com qualidade equivalente continua hipótese. Os estudos externos foram
+lidos em recortes; seus testes não foram executados aqui.
+
+O playground da Alan Studios é acervo de famílias e precedentes, não prova
+de que este harness produziu aqueles jogos e não base aprovada para copiar
+ paleta ou feel.
+
+## Continuidade
+
+- **Onde estamos:** o harness 0.8 cobria processo, scan e arquitetura
+  proporcional. Faltavam o caminho curto da primeira sessão, o feel e o
+  áudio como focos, e um contrato explícito de ambição.
+- **Próximo passo:** ao criar ou elevar um jogo, usar este guia com
+  `--focus create` (início), `--focus feel` ou `--focus audio` (acabamento),
+  sem gerar documentos que o recorte não precisa.
+- **Por que agora:** sem isso, o agente documenta demais e polida de menos,
+  ou entrega protótipo como produto.
+- **Pronto quando:** a escala está no brief, o ciclo existe, e o próximo
+  passo da escada está nomeado com prova.
+- **Retomar por:** este guia, [criar](../recipes/create.md),
+  [qualidade](quality.md) e a continuidade do próprio jogo.

--- a/references/ambition.md
+++ b/references/ambition.md
@@ -155,8 +155,10 @@ Nenhuma destas barras é “ser AAA de publisher”.
   observado do próximo trecho é conhecido.
 
 O [protocolo](quality.md) registra cenário, condições, referência, evidência
-técnica e observação em movimento. Sem essa comparação, declare a lacuna.
-Não rebatize uma versão degradada como novo piso.
+técnica e observação em movimento. O instrumento único é o
+[checklist de piso](aaa-checklist.md) (`--stage aaa` / `template aaa`).
+Sem essa comparação, declare a lacuna. Não rebatize uma versão degradada
+como novo piso. Completar o checklist não é nota AAA.
 
 ## O que este repositório continua recusando
 
@@ -182,6 +184,8 @@ paleta ou feel.
 - **Por que agora:** sem a distinção, o agente documenta demais, polida de
   menos, ou usa “AAA” como adjetivo de marketing.
 - **Pronto quando:** a escala está no brief (jam / produto / AA–Triple-I),
-  o ciclo existe, e o próximo passo da escada está nomeado com prova.
+  o ciclo existe, o próximo passo da escada está nomeado com prova, e o
+  [checklist](aaa-checklist.md) do recorte tem estado ou N/A em cada item
+  aplicável.
 - **Retomar por:** este guia, [criar](../recipes/create.md),
   [qualidade](quality.md) e a continuidade do próprio jogo.

--- a/references/game-design-system.md
+++ b/references/game-design-system.md
@@ -72,8 +72,8 @@ certifica tokens, consumidores nem aprovação artística.
 - **Onde estamos:** o contrato do estúdio existe; as instâncias continuam no documento
   canônico de cada jogo, com profundidade desigual.
 - **Próximo passo:** ao trabalhar num jogo identificável, preencher ou recuperar a
-  instância dele — tokens com consumidor, feel do verbo, mix da consequência e
-  uma receita de conteúdo novo.
+  instância dele — tokens com consumidor, feel do verbo sincronizado no impacto,
+  mix da consequência e uma receita de conteúdo novo (repeatability).
 - **Por que agora:** sem isso, arte e UI novas improvisam e o piso aprovado não se
   reproduz.
 - **Pronto quando:** as nove áreas acima têm fato, hipótese ou lacuna com próxima ação,

--- a/references/game-design-system.md
+++ b/references/game-design-system.md
@@ -46,13 +46,19 @@ ativo; localize o uso real.
 2. **Tokens:** papéis nomeados e, quando existirem, o caminho do consumidor.
 3. **Componentes do mundo:** famílias recorrentes e como um item novo nasce.
 4. **Feel / feedback:** sinal percebido da ação central; ligar ao verbo do GDD.
-5. **UI / HUD / acesso:** ou a decisão explícita de não ter interface tradicional.
-6. **Fazer / não fazer:** um exemplo que cabe e um que quebra a direção.
-7. **Proveniência:** origem, crédito e condição de uso dos recursos.
-8. **Verificação:** cenário de comparação em movimento, nas mesmas condições.
+   Cadeia: intenção → input → antecipação → corpo → impacto → câmera → áudio
+   → recuperação. Receita: [feel](../recipes/feel.md).
+5. **Áudio / mix:** papéis (ação, mundo, música, stinger, silêncio), consumidor
+   real e interrupção. Piso de gravação licenciada salvo direção explícita em
+   contrário. Receita: [áudio](../recipes/audio.md).
+6. **UI / HUD / acesso:** ou a decisão explícita de não ter interface tradicional.
+7. **Fazer / não fazer:** um exemplo que cabe e um que quebra a direção.
+8. **Proveniência:** origem, crédito e condição de uso dos recursos.
+9. **Verificação:** cenário de comparação em movimento, nas mesmas condições.
 
-GDD define o que o jogador faz. O design system define como isso se parece, soa e
-se multiplica. MDA continua sendo hipótese de experiência, não paleta.
+GDD define o que o jogador faz. O design system define como isso se parece, soa,
+pesa e se multiplica. MDA continua sendo hipótese de experiência, não paleta.
+Áudio deixou de ser sub-item de feel: mix e silêncio têm consumidor próprio.
 
 ## Quando preencher
 
@@ -66,9 +72,10 @@ certifica tokens, consumidores nem aprovação artística.
 - **Onde estamos:** o contrato do estúdio existe; as instâncias continuam no documento
   canônico de cada jogo, com profundidade desigual.
 - **Próximo passo:** ao trabalhar num jogo identificável, preencher ou recuperar a
-  instância dele — tokens com consumidor, feel do verbo e uma receita de conteúdo novo.
+  instância dele — tokens com consumidor, feel do verbo, mix da consequência e
+  uma receita de conteúdo novo.
 - **Por que agora:** sem isso, arte e UI novas improvisam e o piso aprovado não se
   reproduz.
-- **Pronto quando:** as oito áreas acima têm fato, hipótese ou lacuna com próxima ação,
+- **Pronto quando:** as nove áreas acima têm fato, hipótese ou lacuna com próxima ação,
   e o próximo asset tem uma receita observável.
 - **Retomar por:** este guia, o Art Bible do jogo e os consumidores rastreados no código.

--- a/references/preproduction.md
+++ b/references/preproduction.md
@@ -205,8 +205,10 @@ sem apresentar todas as PoCs como se fossem uma única tarefa nem recomeçar o c
 
 `context <projeto> --stage gdd` adiciona guia e template GDD aos caminhos selecionados.
 `template gdd --project <projeto>` imprime o rascunho; `--output <arquivo-novo>` o
-salva recusando destino existente. `--stage aaa` / `template aaa` carrega o
-[checklist de piso](aaa-checklist.md); preencher linhas não certifica o jogo.
+salva recusando destino existente. `--stage vertical-slice` e `--stage qa` carregam a
+[guia do piso](aaa-checklist.md). `--stage aaa` / `template aaa` materializa
+o rascunho inteiro; preencher linhas não certifica o jogo. Observe o perfil
+em `finish` (núcleo / produto / promessa).
 A escolha e leitura do documento canônico são
 responsabilidade do agente. O comando não preenche design, revisa mérito ou cria um jogo.
 

--- a/references/preproduction.md
+++ b/references/preproduction.md
@@ -8,8 +8,10 @@ Em qualquer pedido sobre um jogo, comece pelo `context`: a checagem `foundation`
 é automática, mesmo em ajustes localizados. Ao encontrar lacunas, avise e inicie a
 [documentação automática](project-audit.md), sem pedir consentimento. A reconstrução
 de um jogo existente segue aquele roteiro; não exige
-reiniciar seu ciclo criativo nem preencher documentos sem evidência. O design system do jogo (Art Bible) e o
-Devlog complementam este ciclo quando o conteúdo ainda não tem registro canônico.
+reiniciar seu ciclo criativo nem preencher documentos sem evidência. O design system do jogo (Art Bible), o Devlog e o
+[checklist de piso](aaa-checklist.md) (`aaa`) complementam este ciclo quando
+o conteúdo ainda não tem registro canônico. O checklist observa o acabamento
+da fatia; não substitui GDD nem certifica publisher.
 Todo jogo identificável precisa da instância; o arquivo separado é opcional se outro
 canônico cobrir as seções. O contrato do estúdio está no
 [design system do jogo](game-design-system.md).
@@ -203,7 +205,9 @@ sem apresentar todas as PoCs como se fossem uma única tarefa nem recomeçar o c
 
 `context <projeto> --stage gdd` adiciona guia e template GDD aos caminhos selecionados.
 `template gdd --project <projeto>` imprime o rascunho; `--output <arquivo-novo>` o
-salva recusando destino existente. A escolha e leitura do documento canônico são
+salva recusando destino existente. `--stage aaa` / `template aaa` carrega o
+[checklist de piso](aaa-checklist.md); preencher linhas não certifica o jogo.
+A escolha e leitura do documento canônico são
 responsabilidade do agente. O comando não preenche design, revisa mérito ou cria um jogo.
 
 `check-plan` continua validando o registro de reuso; não é validador semântico de

--- a/references/preproduction.md
+++ b/references/preproduction.md
@@ -24,8 +24,9 @@ Não reinicie a pré-produção. **Jogo pequeno / jam / conto:** um `game-design
 reunir brief, GDD, requisitos, decisões técnicas e experimentos. Use os templates
 como perguntas, sem duplicar a mesma informação em nove arquivos. **Produto:**
 separe os documentos que têm responsabilidade e ritmo de atualização distintos.
-**AAA-shaped:** os mesmos artefatos; feel, áudio, luz, animação e receita de
-conteúdo entram como requisitos do recorte, não como fase posterior de polimento.
+**AA / Triple-I (piso de acabamento):** os mesmos artefatos; feel, áudio, luz,
+animação, pacing e receita de conteúdo entram como requisitos do recorte, não
+como fase posterior de polimento. Não é tier de publisher.
 Linke fontes canônicas e mantenha IDs estáveis.
 
 A escala vive no brief. Ela muda quantidade de documentos e de conteúdo, não o
@@ -135,12 +136,16 @@ acabamento pretendido. Demonstra a experiência e a capacidade de produzir mais
 conteúdo nesse padrão. Entrada: recorte e decisões de design/implementação.
 
 **Pronto para ampliar:** cenário jogável e repetível, integrações verificadas,
-comparação em movimento e regressões resolvidas. Feel do verbo e mix da
-consequência fazem parte do acabamento, não de um recorte futuro. A slice
-precisa demonstrar que outro trecho nasce no mesmo padrão (receita de conteúdo,
-custo observado). Cobertura parcial e avaliação do agente permanecem distintas
-de aprovação do usuário. Placeholders podem servir a uma PoC; não certificam o
-acabamento da vertical slice. Scaffold com HUD bonito também não.
+comparação em movimento e regressões resolvidas. Feel do verbo (sincronizado
+no impacto), mix e pacing do trecho fazem parte do acabamento, não de um
+recorte futuro. A slice precisa demonstrar **repeatability**: outro trecho
+nasce no mesmo padrão, pela receita, sem intervenção excepcional, com custo
+observado. Quatro eixos: valor para o jogador, viabilidade técnica, produção
+repetível, clareza do produto. Forte num eixo não compensa vermelho noutro.
+Cobertura parcial e avaliação do agente permanecem distintas de aprovação do
+usuário. Placeholders podem servir a uma PoC; não certificam o acabamento da
+vertical slice. Scaffold com HUD bonito, ou slice “hand-tuned” que ignora o
+pipeline, também não.
 [Template](../assets/templates/vertical-slice.md).
 
 ### `mvp` — Minimum Viable Product

--- a/references/preproduction.md
+++ b/references/preproduction.md
@@ -20,11 +20,16 @@ mesmo quando arquivos antigos cobrem nominalmente as nove áreas. Use o evento
 ## Escolher a profundidade
 
 **Ajuste localizado:** atualize decisão, requisito e caso de QA no registro existente.
-Não reinicie a pré-produção. **Jogo pequeno:** um `game-design.md` pode reunir brief,
-GDD, requisitos, decisões técnicas e experimentos. Use os templates como perguntas,
-sem duplicar a mesma informação em nove arquivos. **Projeto com sistemas/equipe
-maiores:** separe os documentos que têm responsabilidade e ritmo de atualização
-distintos. Linke suas fontes canônicas, mantendo IDs estáveis.
+Não reinicie a pré-produção. **Jogo pequeno / jam / conto:** um `game-design.md` pode
+reunir brief, GDD, requisitos, decisões técnicas e experimentos. Use os templates
+como perguntas, sem duplicar a mesma informação em nove arquivos. **Produto:**
+separe os documentos que têm responsabilidade e ritmo de atualização distintos.
+**AAA-shaped:** os mesmos artefatos; feel, áudio, luz, animação e receita de
+conteúdo entram como requisitos do recorte, não como fase posterior de polimento.
+Linke fontes canônicas e mantenha IDs estáveis.
+
+A escala vive no brief. Ela muda quantidade de documentos e de conteúdo, não o
+piso do verbo. Contrato: [ambição](ambition.md).
 
 Ao iniciar, resolva o pedido, artefatos atuais e referência aprovada. Extraia o que
 já foi decidido; identifique hipóteses e lacunas. Pergunte somente por decisão
@@ -130,9 +135,12 @@ acabamento pretendido. Demonstra a experiência e a capacidade de produzir mais
 conteúdo nesse padrão. Entrada: recorte e decisões de design/implementação.
 
 **Pronto para ampliar:** cenário jogável e repetível, integrações verificadas,
-comparação em movimento e regressões resolvidas. Cobertura parcial e avaliação do
-agente permanecem distintas de aprovação do usuário. Placeholders podem servir a
-uma PoC; não certificam o acabamento da vertical slice.
+comparação em movimento e regressões resolvidas. Feel do verbo e mix da
+consequência fazem parte do acabamento, não de um recorte futuro. A slice
+precisa demonstrar que outro trecho nasce no mesmo padrão (receita de conteúdo,
+custo observado). Cobertura parcial e avaliação do agente permanecem distintas
+de aprovação do usuário. Placeholders podem servir a uma PoC; não certificam o
+acabamento da vertical slice. Scaffold com HUD bonito também não.
 [Template](../assets/templates/vertical-slice.md).
 
 ### `mvp` — Minimum Viable Product

--- a/references/process.md
+++ b/references/process.md
@@ -60,6 +60,9 @@ Produza um ciclo curto com entrada, decisão, consequência e reinício, adequad
 gênero. Resolva primeiro a incerteza que pode invalidar a experiência. Use valores
 existentes como ponto de partida, não como constantes universais. Transforme uma
 variável relevante por vez quando precisar atribuir causa a um resultado.
+O ciclo sem feel e sem áudio da ação continua incompleto: trate `--focus feel`
+e `--focus audio` como parte da fatia, não como enfeite posterior. Escala e
+piso: [ambição](ambition.md).
 
 Preserve separação entre regra, apresentação e conteúdo **onde ela já existe**.
 Não converta todos os jogos para um ECS, schema, relógio ou servidor comum. Ferramentas

--- a/references/project-audit.md
+++ b/references/project-audit.md
@@ -164,9 +164,11 @@ os registros afetados, sem repetir a pré-produção inteira.
 4. **Recuperar design:** reconstrua GDD e requisitos observáveis do comportamento.
    Relacione MDA como intenção documentada ou hipótese do auditor. Separe o que
    existe, o que contradiz a documentação e o que permanece desconhecido.
-5. **Recuperar direção e origem:** examine arte/áudio/UI/câmera e referências
-   disponíveis; identifique componentes, tokens e convenções reais. Não produza
-   aprovação visual por inspeção de arquivos. Identifique assets e créditos.
+5. **Recuperar direção e origem:** examine arte/áudio/UI/câmera, feel do verbo
+   e referências disponíveis; identifique componentes, tokens e convenções reais.
+   Não produza aprovação visual ou sonora por inspeção de arquivos. Identifique
+   assets e créditos. Mix e interrupção seguem a receita de áudio quando o
+   recorte os tiver.
    Rastreie consumidores: um arquivo de paleta sem importação não descreve a UI
    ativa; procure também estilos locais, sprites, materiais e overrides utilizados.
 6. **Recuperar histórico e prova:** examine decisões, devlog, commits pertinentes e

--- a/references/quality.md
+++ b/references/quality.md
@@ -32,9 +32,11 @@ diversão. Um playtest curto bem observado vale mais que uma nota inventada.
 ## Feel da ação
 
 A ação central precisa de peso, timing e recuperação. Antecipação, impacto
-(hitstop, squash, partículas, rumble, stinger) e câmera confirmam o verbo;
-juice que esconde a consequência é regressão. Ajuste um elo por vez e compare
-em movimento. Screenshot não comprova feel. Receita: [feel](../recipes/feel.md).
+(hitstop, squash, partículas, rumble, stinger) e câmera confirmam o verbo.
+Flash, hit-pause, shake, partícula e áudio disparam no **mesmo frame** do
+contato; dessincronia vira dois eventos. Juice que esconde a consequência é
+regressão. Ajuste um elo por vez e compare em movimento. Screenshot não
+comprova feel. Receita: [feel](../recipes/feel.md).
 
 ## Mix e silêncio
 
@@ -62,6 +64,11 @@ A primeira ação ensina o verbo. Mural de texto que bloqueia o jogo não é
 onboarding. Contraste, forma além da cor, foco, alvos de toque e movimento
 reduzido entram quando o recorte os exige — não como anexo depois do “polimento”.
 
+O primeiro minuto também denuncia **latência e pacing**. Spike de frametime
+quebra suavidade e desempenho percebido com mais força do que baixar um
+preset de textura. Observe input, frame e câmera no trecho real antes de
+discutir fidelidade gráfica. Não corte o piso aprovado para “ganhar FPS”.
+
 ## Estado e confiança
 
 Iniciar, jogar, pausar, perder, ganhar, reiniciar e sair precisam ter consequências
@@ -71,11 +78,13 @@ multiplayer precisa explicitar quem pode agir e quem decide o resultado.
 
 ## Piso da escala, não nota
 
-Jam, produto e AAA-shaped compartilham o piso do verbo e diferem na quantidade
-de conteúdo e de artefatos. Não chame o recorte de AAA — nem de “quase AAA” —
-se a vertical slice não demonstra as barras que a escala escolheu. Contrato:
-[ambição](ambition.md). Scaffold demonstra estrutura; slice demonstra
-experiência. Confundi-los é declarar vitória cedo demais.
+Jam, produto e AA / Triple-I compartilham o piso do verbo e diferem na
+quantidade de conteúdo e de artefatos. “AAA” neste texto é piso de
+acabamento, não tier de publisher. Não chame o recorte de AAA — nem de
+“quase AAA” — se a vertical slice não demonstra as barras (feel sincronizado,
+mix, pacing, mundo, repeatability). Contrato: [ambição](ambition.md).
+Scaffold demonstra estrutura; slice demonstra experiência e que outro trecho
+nasce sem heroísmo. Confundi-los é declarar vitória cedo demais.
 
 ## Protocolo de observação
 

--- a/references/quality.md
+++ b/references/quality.md
@@ -29,15 +29,38 @@ decisões ou domínio, não apenas aumentar números. Meça comportamentos obser
 (hesitação, erro repetido, abandono, estratégia), sem confundir tempo de sessão com
 diversão. Um playtest curto bem observado vale mais que uma nota inventada.
 
-## Mundo e direção visual
+## Feel da ação
 
-Escala, câmera, silhuetas, materiais, iluminação e áudio formam uma direção coerente.
-Landmarks ajudam orientação; ameaças e caminhos precisam ser legíveis em movimento.
-A versão visual aprovada é o piso. Não diminua detalhes, sombras, reflexos, animação
-ou efeitos para atingir FPS. Investigue implementações mais eficientes e registre
-custo quando a expansão visual exigir mais recursos. O
+A ação central precisa de peso, timing e recuperação. Antecipação, impacto
+(hitstop, squash, partículas, rumble, stinger) e câmera confirmam o verbo;
+juice que esconde a consequência é regressão. Ajuste um elo por vez e compare
+em movimento. Screenshot não comprova feel. Receita: [feel](../recipes/feel.md).
+
+## Mix e silêncio
+
+O jogador ouve causa e efeito. Camadas (ação, ambiente, música, UI) têm
+prioridade; pause/reinício não deixam voz fantasma. Silêncio é design, não
+arquivo ausente. Piso: gravação licenciada ou direção contemporânea explícita
+— 8-bit, chiptune, jsfxr e Kenney arcade não são o padrão. Receita:
+[áudio](../recipes/audio.md).
+
+## Mundo, luz e animação
+
+Escala, câmera, silhuetas, materiais, iluminação e animação formam uma direção
+coerente. Landmarks ajudam orientação; ameaças e caminhos precisam ser
+legíveis em movimento. Antecipação e follow-through da animação pertencem ao
+verbo, não só à “beleza”. A versão visual aprovada é o piso. Não diminua
+detalhes, sombras, reflexos, animação ou efeitos para atingir FPS. Investigue
+implementações mais eficientes e registre custo quando a expansão visual
+exigir mais recursos. O
 [design system do jogo](game-design-system.md) é o contrato operacional dessa
 direção: tokens, famílias, feel e receita de conteúdo novo, não só o moodboard.
+
+## Primeiro minuto e acesso
+
+A primeira ação ensina o verbo. Mural de texto que bloqueia o jogo não é
+onboarding. Contraste, forma além da cor, foco, alvos de toque e movimento
+reduzido entram quando o recorte os exige — não como anexo depois do “polimento”.
 
 ## Estado e confiança
 
@@ -45,6 +68,14 @@ Iniciar, jogar, pausar, perder, ganhar, reiniciar e sair precisam ter consequên
 definidas. Teste o que sobrevive a cada transição: score, timers, entidades, som,
 inputs, progresso e conexões. Jogo narrativo precisa respeitar histórico e save;
 multiplayer precisa explicitar quem pode agir e quem decide o resultado.
+
+## Piso da escala, não nota
+
+Jam, produto e AAA-shaped compartilham o piso do verbo e diferem na quantidade
+de conteúdo e de artefatos. Não chame o recorte de AAA — nem de “quase AAA” —
+se a vertical slice não demonstra as barras que a escala escolheu. Contrato:
+[ambição](ambition.md). Scaffold demonstra estrutura; slice demonstra
+experiência. Confundi-los é declarar vitória cedo demais.
 
 ## Protocolo de observação
 

--- a/references/quality.md
+++ b/references/quality.md
@@ -101,6 +101,9 @@ Para cada critério afetado registre no local de QA existente:
 - **Conclusão:** critério atendido, regressão ou pendência. Não declare aprovação
   do usuário quando só houve avaliação do agente.
 
+Instrumento único por recorte: [checklist de piso](aaa-checklist.md)
+(`--stage aaa`). Não some itens para uma nota.
+
 Origens: o [playground](https://games.alanicolas.com/), os recortes em
 [sources.md](sources.md) e a direção de qualidade deste repositório. Os estudos
 são referências históricas; suas medições não foram repetidas só por entrarem

--- a/references/quality.md
+++ b/references/quality.md
@@ -101,8 +101,9 @@ Para cada critério afetado registre no local de QA existente:
 - **Conclusão:** critério atendido, regressão ou pendência. Não declare aprovação
   do usuário quando só houve avaliação do agente.
 
-Instrumento único por recorte: [checklist de piso](aaa-checklist.md)
-(`--stage aaa`). Não some itens para uma nota.
+Instrumento: [checklist de piso](aaa-checklist.md). O `context` diz o perfil
+em `finish` (núcleo / produto / promessa). `--stage aaa` só imprime o
+rascunho inteiro. Não some itens para uma nota.
 
 Origens: o [playground](https://games.alanicolas.com/), os recortes em
 [sources.md](sources.md) e a direção de qualidade deste repositório. Os estudos

--- a/references/sources.md
+++ b/references/sources.md
@@ -60,6 +60,41 @@ em qualidade, Art Bible e no playground. Não extraem um kit universal de juice
 nem um motor de mix. Não há recorte externo promovido a testado para esses
 focos; `studies` permanece vazio até existir catálogo pertinente.
 
+## AAA: tier e piso (0.9)
+
+Leitura de 9 de setembro de 2026. Nenhum teste desses textos foi executado
+neste repositório. Orçamentos e headcounts são contexto de mercado, não meta
+do harness.
+
+**Tier de mercado (o rótulo financeiro):**
+
+- [AAA (video game industry)](https://en.wikipedia.org/wiki/AAA_(video_game_industry))
+  — publisher médio/grande, orçamento e marketing; origem em nota de crédito;
+  AA / Triple-I / AAAA como termos vizinhos sem certificação.
+- [Bernevega & Gekker, *Games and Culture*](https://doi.org/10.1177/15554120211014151)
+  — AAA como mercadoria de maior aposta, não como grau criativo.
+- [Video Game Canon — What is a AAA game?](https://www.videogamecanon.com/adventurelog/what-is-a-aaa-game/)
+  — história do empréstimo da nota de crédito.
+- CMA do Reino Unido (2023), citada na Wikipedia: média ~US$ 200 mi para AAA
+  greenlitados a 2024–25. Números de *Call of Duty* / *GTA V* são reportagem,
+  não medição nossa.
+
+**Piso de acabamento (o que o jogador percebe):**
+
+- Steve Swink, *Game Feel* — controle em tempo real, espaço simulado, polish.
+  [Verbete](https://en.wikipedia.org/wiki/Game_feel).
+- Jonasson & Purho, [Juice it or lose it](https://www.youtube.com/watch?v=Fy0aCDmgnxg)
+  (GDC) — som como juice de maior retorno; efeitos que não mudam a regra.
+- Tokey et al., i3D 2026 — spike de frametime domina suavidade e pontuação
+  num FPS; fidelidade gráfica muda a nota visual, pouco o desempenho.
+  [Página](https://web.cs.wpi.edu/~claypool/papers/frame-stutter-graphics-i3d-26/).
+- Vertical slice como trava de qualidade → tempo de asset → headcount: prática
+  de pipeline (publisher gates). Repeatability: outro trecho sem heroísmo.
+
+Blogs de estúdio/agência de 2025–26 (orçamento, AA vs AAA, consistência visual)
+informaram o vocabulário contemporâneo; não foram promovidos a regra testada.
+O harness adapta o **piso** e recusa o **tier** como objetivo.
+
 ## Áudio (catálogo)
 
 O acervo `shared/sfx` é do laboratório, não deste repositório. O harness expõe

--- a/references/sources.md
+++ b/references/sources.md
@@ -93,7 +93,9 @@ do harness.
 
 Blogs de estúdio/agência de 2025–26 (orçamento, AA vs AAA, consistência visual)
 informaram o vocabulário contemporâneo; não foram promovidos a regra testada.
-O harness adapta o **piso** e recusa o **tier** como objetivo.
+O harness adapta o **piso** e recusa o **tier** como objetivo. O instrumento
+preenchível é o [checklist](aaa-checklist.md) (`--stage aaa`); não é um
+score nem uma extração testada desses textos.
 
 ## Áudio (catálogo)
 

--- a/references/sources.md
+++ b/references/sources.md
@@ -52,10 +52,19 @@ A receita [architecture](../recipes/architecture.md) adapta processo transversal
 observado no Architect AIOX, sem copiar o runtime, o roteador de engines nem a
 hierarquia de agentes. Estudo e hashes ficam no laboratório.
 
-## Áudio
+## Feel, áudio e ambição (0.9)
+
+As receitas [feel](../recipes/feel.md) e [áudio](../recipes/audio.md) e o
+contrato [ambição](ambition.md) sistematizam o piso de acabamento já implícito
+em qualidade, Art Bible e no playground. Não extraem um kit universal de juice
+nem um motor de mix. Não há recorte externo promovido a testado para esses
+focos; `studies` permanece vazio até existir catálogo pertinente.
+
+## Áudio (catálogo)
 
 O acervo `shared/sfx` é do laboratório, não deste repositório. O harness expõe
 `sfx search` / `sfx copy` quando essa pasta existir na raiz de `--root`.
+A receita de áudio orienta mix e interrupção; o catálogo só localiza arquivos.
 
 ## Playground
 

--- a/scripts/game.py
+++ b/scripts/game.py
@@ -42,7 +42,7 @@ import sfx_catalog
 
 ROOT = default_root()
 STUDIES_ROOT = default_studies_root(ROOT)
-FOCI = ("create", "mechanics", "lifecycle", "content", "visual", "network", "architecture")
+FOCI = ("create", "mechanics", "lifecycle", "content", "visual", "audio", "feel", "network", "architecture")
 STAGES = ("brief", "mda", "gdd", "poc", "prd", "tdd", "vertical-slice", "mvp", "qa", "art-bible", "devlog", "audit")
 EVENTS = ("task", "direction-approved", "resume")
 CONTINUITY_PATTERN = r"\b(continuidade|continuity|retomada|proxim[ao]s? (passos?|acoes|acao|tarefas?)|next steps?)\b"
@@ -456,8 +456,10 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
         references.append(FRAMEWORK / "recipes/architecture.md")
     if stage or focus == "create":
         references.append(FRAMEWORK / "references/preproduction.md")
-    if focus in ("create", "visual") or stage == "art-bible":
+    if focus in ("create", "visual", "audio", "feel") or stage == "art-bible":
         references.append(FRAMEWORK / "references/game-design-system.md")
+    if focus in ("create", "audio", "feel") or stage in ("brief", "vertical-slice"):
+        references.append(FRAMEWORK / "references/ambition.md")
     if stage:
         references.append(FRAMEWORK / f"assets/templates/{stage}.md")
     if document_minimum or stage in ("art-bible", "devlog"):
@@ -500,6 +502,7 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
             "capabilities.mentioned é só token em arquivo de inspeção. Não prova pause, reset, seed nem determinismo.",
             "capabilities.unknown significa não localizado na lista fixa de arquivos de inspeção, não capacidade ausente; rastreie o entrypoint e os consumidores na auditoria.",
             "Áudio novo: busque em shared/sfx (`sfx search`) antes de baixar. Piso de gravação licenciada; 8-bit, chiptune, jsfxr e Kenney arcade não são o padrão.",
+            "Feel e áudio são focos próprios (`--focus feel`, `--focus audio`). Sem observação em movimento, experience_status permanece not_assessed; scaffold não é vertical slice.",
         ],
     }
 

--- a/scripts/game.py
+++ b/scripts/game.py
@@ -54,11 +54,15 @@ FOUNDATION_AREAS = (
     ("architecture", "Arquitetura atual / TDD", r"\b(tdd|arquitetura|architecture|technical design|contratos tecnicos)\b"),
     ("art_direction", "Design system do jogo / Art Bible", r"^design$|\b(art bible|art-bible|art direction|design system|design-system|game design system|direcao de arte|direcao visual|direcao audiovisual|style guide|visual style|feel bible)\b"),
     ("decisions", "Decisões e histórico / Devlog", r"\b(devlog|decision log|decisions|decisoes|changelog|aprendizados|historico de decisoes|adr)\b"),
-    ("qa", "QA e playtest", r"\b(qa|playtest|test plan|verification|verificacao|validacao|plano de testes)\b"),
+    ("qa", "QA e playtest", r"\b(qa|playtest|test plan|verification|verificacao|validacao|plano de testes|checklist de piso|piso de acabamento|chk-\d)\b"),
     ("runbook", "Como executar e verificar", r"\b(runbook|getting started|setup|instalacao|executar|rodar|desenvolvimento|development|jogar|build|package)\b"),
     ("provenance", "Origem de código e assets", r"\b(licenses?|licences?|licencas?|copying|authors|sources|proveniencia|provenance|creditos|credits|asset sources)\b"),
 )
 CAPABILITIES = ("pause", "reset", "seed", "observe", "act", "advance", "capture", "dispose")
+FINISH_CORE = ("CHK-0", "CHK-1", "CHK-2", "CHK-4", "CHK-5", "CHK-6", "CHK-11")
+FINISH_PRODUCT = ("CHK-3", "CHK-7", "CHK-8", "CHK-10", "CHK-14", "CHK-15")
+FINISH_PROMISE = ("CHK-9", "CHK-12", "CHK-13")
+FINISH_MARKET = ("CHK-16",)
 SKIP = {"node_modules", "dist", "build", "docs", "framework", "squads", "public", "assets", "Assets", "Library", "Temp", "outputs", "shared"}
 FOCUS_STUDIES = {
     "create": (
@@ -460,8 +464,9 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
         references.append(FRAMEWORK / "references/game-design-system.md")
     if focus in ("create", "audio", "feel") or stage in ("brief", "vertical-slice", "aaa"):
         references.append(FRAMEWORK / "references/ambition.md")
-    if stage == "aaa":
+    if focus in ("create", "feel", "audio") or stage in ("aaa", "vertical-slice", "qa"):
         references.append(FRAMEWORK / "references/aaa-checklist.md")
+    if stage == "aaa":
         for extra in ("feel", "audio"):
             path = FRAMEWORK / f"recipes/{extra}.md"
             if path not in references:
@@ -498,6 +503,17 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
             "before_close": "Registrar conteúdo e fontes nos documentos canônicos; cobrir cada área mínima com decisão/fato ou lacuna e próxima ação. Referência salva e templates vazios não concluem a documentação.",
             "scope": "O agente executa a ação e respeita restrições atuais do usuário. O comando não escreve documentos, concede aprovação ou certifica sua suficiência.",
         },
+        "finish": {
+            "guide": str(FRAMEWORK / "references/aaa-checklist.md"),
+            "template": str(FRAMEWORK / "assets/templates/aaa.md"),
+            "core_groups": list(FINISH_CORE),
+            "product_groups": list(FINISH_PRODUCT),
+            "promise_groups": list(FINISH_PROMISE),
+            "market_groups": list(FINISH_MARKET),
+            "action": "observe_core_on_slice" if stage in ("aaa", "vertical-slice", "qa") or focus in ("feel", "audio") else "defer_until_playable_cycle",
+            "executed": False,
+            "scope": "Núcleo em qualquer escala após um ciclo jogável. Produto/AA soma product_groups. Promessa só se o brief prometeu. Mercado (CHK-16) nunca reprova jam. Completar o template não certifica. O comando não observa o jogo.",
+        },
         "studio_assets": sfx_catalog.studio_assets(),
         "limits": [
             "Ponteiros não comprovam leitura; scripts declarados não comprovam execução.",
@@ -510,7 +526,7 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
             "Áudio novo: busque em shared/sfx (`sfx search`) antes de baixar. Piso de gravação licenciada; 8-bit, chiptune, jsfxr e Kenney arcade não são o padrão.",
             "Feel e áudio são focos próprios (`--focus feel`, `--focus audio`). Sem observação em movimento, experience_status permanece not_assessed; scaffold não é vertical slice.",
             "“AAA” neste harness é piso de acabamento da slice, não tier de publisher. Sem feel sincronizado, pacing e repeatability, não use o adjetivo.",
-            "Checklist preenchível: `template aaa` ou `context --stage aaa`. Completar linhas não certifica o jogo; N/A exige motivo.",
+            "Checklist: ver finish no JSON. Jam observa core_groups; produto/AA soma product_groups; promise_groups só se prometidos. `template aaa` não certifica; N/A exige motivo.",
         ],
     }
 

--- a/scripts/game.py
+++ b/scripts/game.py
@@ -43,7 +43,7 @@ import sfx_catalog
 ROOT = default_root()
 STUDIES_ROOT = default_studies_root(ROOT)
 FOCI = ("create", "mechanics", "lifecycle", "content", "visual", "audio", "feel", "network", "architecture")
-STAGES = ("brief", "mda", "gdd", "poc", "prd", "tdd", "vertical-slice", "mvp", "qa", "art-bible", "devlog", "audit")
+STAGES = ("brief", "mda", "gdd", "poc", "prd", "tdd", "vertical-slice", "mvp", "qa", "art-bible", "devlog", "audit", "aaa")
 EVENTS = ("task", "direction-approved", "resume")
 CONTINUITY_PATTERN = r"\b(continuidade|continuity|retomada|proxim[ao]s? (passos?|acoes|acao|tarefas?)|next steps?)\b"
 CONTINUITY_FILES = {"production plan", "plano de producao", "roadmap", "backlog", "state", "decisions", "devlog"}
@@ -456,10 +456,16 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
         references.append(FRAMEWORK / "recipes/architecture.md")
     if stage or focus == "create":
         references.append(FRAMEWORK / "references/preproduction.md")
-    if focus in ("create", "visual", "audio", "feel") or stage == "art-bible":
+    if focus in ("create", "visual", "audio", "feel") or stage in ("art-bible", "aaa"):
         references.append(FRAMEWORK / "references/game-design-system.md")
-    if focus in ("create", "audio", "feel") or stage in ("brief", "vertical-slice"):
+    if focus in ("create", "audio", "feel") or stage in ("brief", "vertical-slice", "aaa"):
         references.append(FRAMEWORK / "references/ambition.md")
+    if stage == "aaa":
+        references.append(FRAMEWORK / "references/aaa-checklist.md")
+        for extra in ("feel", "audio"):
+            path = FRAMEWORK / f"recipes/{extra}.md"
+            if path not in references:
+                references.append(path)
     if stage:
         references.append(FRAMEWORK / f"assets/templates/{stage}.md")
     if document_minimum or stage in ("art-bible", "devlog"):
@@ -504,6 +510,7 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
             "Áudio novo: busque em shared/sfx (`sfx search`) antes de baixar. Piso de gravação licenciada; 8-bit, chiptune, jsfxr e Kenney arcade não são o padrão.",
             "Feel e áudio são focos próprios (`--focus feel`, `--focus audio`). Sem observação em movimento, experience_status permanece not_assessed; scaffold não é vertical slice.",
             "“AAA” neste harness é piso de acabamento da slice, não tier de publisher. Sem feel sincronizado, pacing e repeatability, não use o adjetivo.",
+            "Checklist preenchível: `template aaa` ou `context --stage aaa`. Completar linhas não certifica o jogo; N/A exige motivo.",
         ],
     }
 

--- a/scripts/game.py
+++ b/scripts/game.py
@@ -503,6 +503,7 @@ def context(project, focus, stage=None, studies_root=None, event="task"):
             "capabilities.unknown significa não localizado na lista fixa de arquivos de inspeção, não capacidade ausente; rastreie o entrypoint e os consumidores na auditoria.",
             "Áudio novo: busque em shared/sfx (`sfx search`) antes de baixar. Piso de gravação licenciada; 8-bit, chiptune, jsfxr e Kenney arcade não são o padrão.",
             "Feel e áudio são focos próprios (`--focus feel`, `--focus audio`). Sem observação em movimento, experience_status permanece not_assessed; scaffold não é vertical slice.",
+            "“AAA” neste harness é piso de acabamento da slice, não tier de publisher. Sem feel sincronizado, pacing e repeatability, não use o adjetivo.",
         ],
     }
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -61,6 +61,34 @@ class HarnessTest(unittest.TestCase):
         self.assertTrue(all(item["status"] in ("unknown", "mentioned") for item in result["capabilities"].values()))
         self.assertTrue(all(item["status"] != "verified" for item in result["capabilities"].values()))
 
+    def test_feel_and_audio_load_design_system_and_ambition_without_writing(self):
+        before = set(self.project.iterdir())
+        for focus, recipe in (("feel", "feel.md"), ("audio", "audio.md")):
+            with self.subTest(focus=focus):
+                result = game.context(self.project, focus, studies_root=self.root / "absent")
+                names = [Path(p).name for p in result["read_next"]]
+                self.assertEqual(result["focus"], focus)
+                self.assertEqual(result["studies"], [])
+                self.assertIn(recipe, names)
+                self.assertIn("game-design-system.md", names)
+                self.assertIn("ambition.md", names)
+                self.assertIn("project-audit.md", names)
+                self.assertTrue(all(Path(p).is_file() for p in result["read_next"]))
+                self.assertIn("Feel e áudio são focos próprios", " ".join(result["limits"]))
+        create = game.context(self.project, "create", studies_root=self.root / "absent")
+        self.assertIn("ambition.md", [Path(p).name for p in create["read_next"]])
+        self.assertIn("preproduction.md", [Path(p).name for p in create["read_next"]])
+        self.assertEqual(before, set(self.project.iterdir()))
+        self.assertEqual(game.FOCI, (
+            "create", "mechanics", "lifecycle", "content", "visual",
+            "audio", "feel", "network", "architecture",
+        ))
+        brief = game.context(self.project, "mechanics", stage="brief")
+        self.assertIn("ambition.md", [Path(p).name for p in brief["read_next"]])
+        self.assertIn("brief.md", [Path(p).name for p in brief["read_next"]])
+        slice_ctx = game.context(self.project, "content", stage="vertical-slice")
+        self.assertIn("ambition.md", [Path(p).name for p in slice_ctx["read_next"]])
+
     def test_context_lists_focus_studies_without_loading_other_catalogs(self):
         studies = self.root / "Games-Frameworks"
         phaser = studies / "outputs/decoded/games-phaser/study-02d8931b626d/validate/rule-catalog.md"

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -75,6 +75,7 @@ class HarnessTest(unittest.TestCase):
                 self.assertIn("project-audit.md", names)
                 self.assertTrue(all(Path(p).is_file() for p in result["read_next"]))
                 self.assertIn("Feel e áudio são focos próprios", " ".join(result["limits"]))
+                self.assertIn("piso de acabamento da slice, não tier de publisher", " ".join(result["limits"]))
         create = game.context(self.project, "create", studies_root=self.root / "absent")
         self.assertIn("ambition.md", [Path(p).name for p in create["read_next"]])
         self.assertIn("preproduction.md", [Path(p).name for p in create["read_next"]])

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -76,9 +76,16 @@ class HarnessTest(unittest.TestCase):
                 self.assertTrue(all(Path(p).is_file() for p in result["read_next"]))
                 self.assertIn("Feel e áudio são focos próprios", " ".join(result["limits"]))
                 self.assertIn("piso de acabamento da slice, não tier de publisher", " ".join(result["limits"]))
+                self.assertIn("aaa-checklist.md", names)
+                self.assertEqual(result["finish"]["action"], "observe_core_on_slice")
+                self.assertIn("CHK-0", result["finish"]["core_groups"])
+                self.assertIn("CHK-16", result["finish"]["market_groups"])
+                self.assertFalse(result["finish"]["executed"])
         create = game.context(self.project, "create", studies_root=self.root / "absent")
         self.assertIn("ambition.md", [Path(p).name for p in create["read_next"]])
         self.assertIn("preproduction.md", [Path(p).name for p in create["read_next"]])
+        self.assertIn("aaa-checklist.md", [Path(p).name for p in create["read_next"]])
+        self.assertEqual(create["finish"]["action"], "defer_until_playable_cycle")
         self.assertEqual(before, set(self.project.iterdir()))
         self.assertEqual(game.FOCI, (
             "create", "mechanics", "lifecycle", "content", "visual",
@@ -89,6 +96,14 @@ class HarnessTest(unittest.TestCase):
         self.assertIn("brief.md", [Path(p).name for p in brief["read_next"]])
         slice_ctx = game.context(self.project, "content", stage="vertical-slice")
         self.assertIn("ambition.md", [Path(p).name for p in slice_ctx["read_next"]])
+        self.assertIn("aaa-checklist.md", [Path(p).name for p in slice_ctx["read_next"]])
+        self.assertNotIn("aaa.md", [Path(p).name for p in slice_ctx["read_next"]])
+        self.assertEqual(slice_ctx["finish"]["action"], "observe_core_on_slice")
+        qa_ctx = game.context(self.project, "mechanics", stage="qa")
+        self.assertIn("aaa-checklist.md", [Path(p).name for p in qa_ctx["read_next"]])
+        visual = game.context(self.project, "visual")
+        self.assertNotIn("aaa-checklist.md", [Path(p).name for p in visual["read_next"]])
+        self.assertEqual(visual["finish"]["action"], "defer_until_playable_cycle")
 
     def test_aaa_stage_loads_checklist_ambition_and_finish_recipes_without_writing(self):
         before = set(self.project.iterdir())
@@ -104,9 +119,19 @@ class HarnessTest(unittest.TestCase):
         self.assertIn("audio.md", names)
         self.assertIn("mechanics.md", names)
         self.assertTrue(all(Path(p).is_file() for p in result["read_next"]))
-        self.assertIn("template aaa", " ".join(result["limits"]))
+        self.assertIn("ver finish no JSON", " ".join(result["limits"]))
+        self.assertEqual(result["finish"]["core_groups"], list(game.FINISH_CORE))
         self.assertEqual(before, set(self.project.iterdir()))
         self.assertIn("aaa", game.STAGES)
+
+    def test_scan_treats_finish_checklist_as_qa_candidate_not_a_tenth_area(self):
+        path = self.project / "docs/piso.md"
+        path.parent.mkdir()
+        path.write_text("# Checklist de piso de acabamento\nCHK-0 contrato do recorte.\nCHK-1 verbo observado.\n")
+        result = game.scan(self.project)
+        self.assertEqual(len(result["areas"]), 9)
+        self.assertEqual(result["areas"]["qa"]["status"], "candidate_found")
+        self.assertEqual(result["areas"]["qa"]["candidates"][0]["path"], "docs/piso.md")
 
     def test_context_lists_focus_studies_without_loading_other_catalogs(self):
         studies = self.root / "Games-Frameworks"

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -90,6 +90,24 @@ class HarnessTest(unittest.TestCase):
         slice_ctx = game.context(self.project, "content", stage="vertical-slice")
         self.assertIn("ambition.md", [Path(p).name for p in slice_ctx["read_next"]])
 
+    def test_aaa_stage_loads_checklist_ambition_and_finish_recipes_without_writing(self):
+        before = set(self.project.iterdir())
+        result = game.context(self.project, "mechanics", stage="aaa", studies_root=self.root / "absent")
+        names = [Path(p).name for p in result["read_next"]]
+        self.assertEqual(result["stage"], "aaa")
+        self.assertEqual(result["focus"], "mechanics")
+        self.assertEqual(names.count("aaa.md"), 1)
+        self.assertIn("aaa-checklist.md", names)
+        self.assertIn("ambition.md", names)
+        self.assertIn("game-design-system.md", names)
+        self.assertIn("feel.md", names)
+        self.assertIn("audio.md", names)
+        self.assertIn("mechanics.md", names)
+        self.assertTrue(all(Path(p).is_file() for p in result["read_next"]))
+        self.assertIn("template aaa", " ".join(result["limits"]))
+        self.assertEqual(before, set(self.project.iterdir()))
+        self.assertIn("aaa", game.STAGES)
+
     def test_context_lists_focus_studies_without_loading_other_catalogs(self):
         studies = self.root / "Games-Frameworks"
         phaser = studies / "outputs/decoded/games-phaser/study-02d8931b626d/validate/rule-catalog.md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## O que mudou

Revisão profunda do que o harness se propõe a fazer. O 0.8 era honesto e proporcional — e denso demais para começar, raso demais no acabamento. O 0.9 torna a criação com IA **fácil de começar** e **difícil de rebaixar**, sem virar motor, hierarquia de agentes ou nota automática de diversão.

### 0.9.3 — Checklist adaptado ao framework

O checklist deixou de ser uma 13ª etapa solta.

- `context` expõe **`finish`**: `core_groups`, `product_groups`, `promise_groups`, `market_groups` e a ação (`defer_until_playable_cycle` ou `observe_core_on_slice`).
- A [guia](references/aaa-checklist.md) entra em create, feel, audio, vertical-slice e QA. `template aaa` / `--stage aaa` só materializa o rascunho inteiro.
- Scanner: documento de piso é candidato de **QA**. Continuam **nove** áreas.
- Skill: primeira sessão **não** gera o template. Slice ou “está AAA?” observa o perfil.
- Template aprofundado: coluna Origem, itens novos (cancelamento, espacialização, 30/60/120, luz vs leitura, fotossensibilidade, gate de import, seed), seções por perfil.

### 0.9.2 — Checklist de piso de acabamento

Etapa `aaa`: [guia](references/aaa-checklist.md) e [template](assets/templates/aaa.md). 16 grupos (CHK-0 a CHK-16). CHK-16 (tier de mercado) começa `N/A`. Completar linhas **não** certifica publisher.

### 0.9.1 — pesquisa AAA dobrada no contrato

Pesquisa de 2026-09-09: AAA de publisher é **rótulo financeiro**. O que o jogador chama de qualidade AAA é **piso de acabamento**. Escala ambiciosa = **AA / Triple-I**. Fontes em [sources.md](references/sources.md#aaa-tier-e-piso-09).

## Como usar o checklist

```sh
python3 scripts/game.py context /caminho/do/jogo --focus create --root /caminho/do/laboratorio
# leia finish.action e finish.core_groups — não gere o template ainda

python3 scripts/game.py context /caminho/do/jogo --stage vertical-slice --root /caminho/do/laboratorio
# observe o núcleo (+ produto se a escala pedir)

python3 scripts/game.py template aaa --project /caminho/do/jogo
# só quando precisar do rascunho inteiro
```

Jam: núcleo (CHK-0, 1, 2, 4, 5, 6, 11). Produto/AA: some produto. Narrativa, rede e locale só se o brief prometeu.

## Entrega 0.9

- Skill com primeira sessão (ciclo → feel → áudio → uma próxima ação).
- Focos `--focus feel` e `--focus audio`.
- Harness 0.9–0.9.3; testes verdes (76).

O harness continua thin: não mede diversão, não publica, não escolhe engine, não certifica mercado.

## Limite honesto

Este PR eleva o **contrato** e o **instrumento de observação**. Não produz um jogo do tier AAA de publisher. O precedente de mercado é AA / Triple-I (*Hellblade*, *Expedition 33*).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08644-c4ec-731b-914b-97114834eeda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08644-c4ec-731b-914b-97114834eeda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `feel` and `audio` focus options for context and recipes.
  * Added an AAA finishing-floor checklist and `aaa` workflow stage.
  * Added guidance for evaluating feel, audio, mix, pacing, accessibility, and repeatability.
  * Added new recipes for feel and audio workflows.
* **Documentation**
  * Clarified that AAA describes slice finish quality, not a publisher or market certification.
  * Expanded templates and references with first-session, audio, feel, and finish-quality guidance.
  * Documented that verification does not independently prove feel or audio quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->